### PR TITLE
Don’t delete avatar when avatar `get_attached_file` call fails

### DIFF
--- a/simple-local-avatars.php
+++ b/simple-local-avatars.php
@@ -92,10 +92,6 @@ class Simple_Local_Avatars {
 		if ( ! empty( $local_avatars['media_id'] ) ) {
 			// has the media been deleted?
 			if ( ! $avatar_full_path = get_attached_file( $local_avatars['media_id'] ) ) {
-				// only allowed logged in users to delete bad data to mitigate performance issues
-				if ( is_user_logged_in() )
-					$this->avatar_delete( $user_id );
-
 				return $avatar;
 			}
 		}


### PR DESCRIPTION
Fix https://github.com/10up/simple-local-avatars/issues/21.

* Fix an issue where if the user is logged in and an avatar load call to `get_attached_file` fails for any reason the _user's avatar (`simple_local_avatar` user meta) is deleted_. 

Because (remote/cloud storage) plugins can hook into `get_attached_file` and may possibly fail, we need to be more cautious about deleting meta. This PR removes the automatic deletion entirely. We already provide a method for users to delete the meta from within wp-admin.