### PR TITLE
Fixed string as int in REST API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "diodoe/simple-local-avatars",
+  "name": "10up/simple-local-avatars", 
   "description": "Adds an avatar upload field to user profiles. Generates requested sizes on demand just like Gravatar!",
   "type": "wordpress-plugin",
   "keywords": [
@@ -7,7 +7,9 @@
     "10up"
   ],
   "homepage": "https://github.com/10up/simple-local-avatars",
-  "license": ["GPL-2.0-or-later"],
+  "license": [
+    "GPL-2.0-or-later"
+  ],
   "authors": [
     {
       "name": "10up",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "10up/simple-local-avatars", 
+  "name": "10up/simple-local-avatars",
   "description": "Adds an avatar upload field to user profiles. Generates requested sizes on demand just like Gravatar!",
   "type": "wordpress-plugin",
   "keywords": [
@@ -7,9 +7,7 @@
     "10up"
   ],
   "homepage": "https://github.com/10up/simple-local-avatars",
-  "license": [
-    "GPL-2.0-or-later"
-  ],
+  "license": ["GPL-2.0-or-later"],
   "authors": [
     {
       "name": "10up",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "10up/simple-local-avatars",
+  "name": "diodoe/simple-local-avatars",
   "description": "Adds an avatar upload field to user profiles. Generates requested sizes on demand just like Gravatar!",
   "type": "wordpress-plugin",
   "keywords": [

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -438,7 +438,7 @@ class Simple_Local_Avatars {
 		$meta_value = array();
 
 		// set the new avatar
-		if ( is_int( $url_or_media_id ) ) {
+		if ( is_numeric( $url_or_media_id ) ) {
 			$meta_value['media_id'] = $url_or_media_id;
 			$url_or_media_id        = wp_get_attachment_url( $url_or_media_id );
 		}

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -438,7 +438,8 @@ class Simple_Local_Avatars {
 		$meta_value = array();
 
 		// set the new avatar
-		if ( is_numeric( $url_or_media_id ) ) {
+		if ( is_numeric( $url_or_media_id ) 
+				&& ((float)$url_or_media_id - (int)$url_or_media_id) == 0 ) {
 			$meta_value['media_id'] = $url_or_media_id;
 			$url_or_media_id        = wp_get_attachment_url( $url_or_media_id );
 		}


### PR DESCRIPTION
### Description of the Change

Bug: send media_id via REST api doesn't work.

### Benefits

You can now refer correctly to a media_id via REST api

### Possible Drawbacks

None
