### PR TITLE
Fix: Media ID as string in REST API

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -438,7 +438,7 @@ class Simple_Local_Avatars {
 		$meta_value = array();
 
 		// set the new avatar
-		if ( is_int( $url_or_media_id ) ) {
+		if ( is_int( $url_or_media_id + 0 ) ) {
 			$meta_value['media_id'] = $url_or_media_id;
 			$url_or_media_id        = wp_get_attachment_url( $url_or_media_id );
 		}


### PR DESCRIPTION
This is a replacement for #69. Props @diodoe for reporting and the PR.