### PR TITLE
Avatar rating text is not translated properly if a user has a custom language Set

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -408,10 +408,10 @@ class Simple_Local_Avatars {
 
                     // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
                     // We also use the default text domain here
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
+                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
+                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
+                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
+                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
 					?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
 					</fieldset></td>

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -407,7 +407,7 @@ class Simple_Local_Avatars {
 					}
 
 					foreach ( $this->avatar_ratings as $key => $rating ) :
-						echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating, $key, false ) . "/> $rating</label><br />";
+						echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating, $key, false ) . "/>" . __($rating) . "</label><br />";
 					endforeach;
 					?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -404,14 +404,12 @@ class Simple_Local_Avatars {
 						<?php
 						$this->update_avatar_ratings();
 
-						if ( empty( $profileuser->simple_local_avatar_rating ) || ! array_key_exists( $profileuser->simple_local_avatar_rating,
-								$this->avatar_ratings ) ) {
+						if ( empty( $profileuser->simple_local_avatar_rating ) || ! array_key_exists( $profileuser->simple_local_avatar_rating, $this->avatar_ratings ) ) {
 							$profileuser->simple_local_avatar_rating = 'G';
 						}
 
 						foreach ( $this->avatar_ratings as $key => $rating ) :
-							echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating,
-									$key, false ) . "/>" . esc_html( $rating ) . "</label><br />";
+							echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating, $key, false ) . "/>" . esc_html( $rating ) . "</label><br />";
 						endforeach;
 						?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
@@ -683,17 +681,17 @@ class Simple_Local_Avatars {
 		$this->assign_new_user_avatar( $input['media_id'], $user->ID );
 	}
 
-    /**
-     * Overwriting existing avatar_ratings so this can be called just before the rating strings would be used so that
-     * translations will work correctly.
-     * Default text-domain because the strings have already been translated
-     */
-    private function update_avatar_ratings() {
-        $this->avatar_ratings = array(
-            'G'  => __( 'G &#8212; Suitable for all audiences' ),
-            'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
-            'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
-            'X'  => __( 'X &#8212; Even more mature than above' ),
-        );
-    }
+	/**
+	 * Overwriting existing avatar_ratings so this can be called just before the rating strings would be used so that
+	 * translations will work correctly.
+	 * Default text-domain because the strings have already been translated
+	 */
+	private function update_avatar_ratings() {
+		$this->avatar_ratings = array(
+			'G'  => __( 'G &#8212; Suitable for all audiences' ),
+			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
+			'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
+			'X'  => __( 'X &#8212; Even more mature than above' ),
+		);
+	}
 }

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -406,9 +406,12 @@ class Simple_Local_Avatars {
 						$profileuser->simple_local_avatar_rating = 'G';
 					}
 
-					foreach ( $this->avatar_ratings as $key => $rating ) :
-						echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating, $key, false ) . "/>" . __($rating) . "</label><br />";
-					endforeach;
+                    // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
+                    // We also use the default text domain here
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
 					?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
 					</fieldset></td>

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -406,12 +406,12 @@ class Simple_Local_Avatars {
 						$profileuser->simple_local_avatar_rating = 'G';
 					}
 
-                    // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
-                    // We also use the default text domain here
-                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
-                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
-                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
-                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
+                            // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
+                            // We also use the default text domain here
+                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
+                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
+                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
+                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
 					?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
 					</fieldset></td>

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -406,12 +406,9 @@ class Simple_Local_Avatars {
 						$profileuser->simple_local_avatar_rating = 'G';
 					}
 
-                                        // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
-                                        // We also use the default text domain here
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
-                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
+                    foreach ( $this->get_avatar_ratings() as $key => $rating ) :
+                        echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating, $key, false ) . "/>" . esc_html($rating) . "</label><br />";
+                    endforeach;
 					?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
 					</fieldset></td>
@@ -681,4 +678,22 @@ class Simple_Local_Avatars {
 	public function set_avatar_rest( $input, $user ) {
 		$this->assign_new_user_avatar( $input['media_id'], $user->ID );
 	}
+
+    /**
+     * Overwriting existing avatar_ratings so this can be called just before the rating strings would be used so that
+     * translations will work correctly.
+     * Default text-domain because the strings have already been translated
+     *
+     * @return array
+     */
+    private function get_avatar_ratings(): array {
+        $this->avatar_ratings = array(
+            'G'  => __( 'G &#8212; Suitable for all audiences' ),
+            'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
+            'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
+            'X'  => __( 'X &#8212; Even more mature than above' ),
+        );
+
+        return $this->avatar_ratings;
+    }
 }

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -401,15 +401,19 @@ class Simple_Local_Avatars {
 				<td colspan="2">
 					<fieldset id="simple-local-avatar-ratings" <?php disabled( empty( $profileuser->simple_local_avatar ) ); ?>>
 						<legend class="screen-reader-text"><span><?php esc_html_e( 'Rating' ); ?></span></legend>
-					<?php
-					if ( empty( $profileuser->simple_local_avatar_rating ) || ! array_key_exists( $profileuser->simple_local_avatar_rating, $this->avatar_ratings ) ) {
-						$profileuser->simple_local_avatar_rating = 'G';
-					}
+						<?php
+						$this->update_avatar_ratings();
 
-                    foreach ( $this->get_avatar_ratings() as $key => $rating ) :
-                        echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating, $key, false ) . "/>" . esc_html($rating) . "</label><br />";
-                    endforeach;
-					?>
+						if ( empty( $profileuser->simple_local_avatar_rating ) || ! array_key_exists( $profileuser->simple_local_avatar_rating,
+								$this->avatar_ratings ) ) {
+							$profileuser->simple_local_avatar_rating = 'G';
+						}
+
+						foreach ( $this->avatar_ratings as $key => $rating ) :
+							echo "\n\t<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( $key ) . "' " . checked( $profileuser->simple_local_avatar_rating,
+									$key, false ) . "/>" . esc_html( $rating ) . "</label><br />";
+						endforeach;
+						?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
 					</fieldset></td>
 			</tr>
@@ -683,17 +687,13 @@ class Simple_Local_Avatars {
      * Overwriting existing avatar_ratings so this can be called just before the rating strings would be used so that
      * translations will work correctly.
      * Default text-domain because the strings have already been translated
-     *
-     * @return array
      */
-    private function get_avatar_ratings(): array {
+    private function update_avatar_ratings() {
         $this->avatar_ratings = array(
             'G'  => __( 'G &#8212; Suitable for all audiences' ),
             'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
             'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
             'X'  => __( 'X &#8212; Even more mature than above' ),
         );
-
-        return $this->avatar_ratings;
     }
 }

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -406,12 +406,12 @@ class Simple_Local_Avatars {
 						$profileuser->simple_local_avatar_rating = 'G';
 					}
 
-                            // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
-                            // We also use the default text domain here
-                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
-                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
-                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
-                            echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
+                                    // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
+                                    // We also use the default text domain here
+                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
+                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
+                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
+                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
 					?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
 					</fieldset></td>

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -406,12 +406,12 @@ class Simple_Local_Avatars {
 						$profileuser->simple_local_avatar_rating = 'G';
 					}
 
-                                    // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
-                                    // We also use the default text domain here
-                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
-                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
-                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
-                                    echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
+                                        // These are the same as $this->avatar_ratings but in order for string translations to appear we have to output them like the following
+                                        // We also use the default text domain here
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'G' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'G', false ) . "/>" . __( 'G &#8212; Suitable for all audiences' ) . "</label><br />";
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'PG' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'PG', false ) . "/>" . __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ) . "</label><br />";
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'R' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'R', false ) . "/>" . __( 'R &#8212; Intended for adult audiences above 17' ) . "</label><br />";
+                                        echo "<label><input type='radio' name='simple_local_avatar_rating' value='" . esc_attr( 'X' ) . "' " . checked( $profileuser->simple_local_avatar_rating, 'X', false ) . "/>" . __( 'X &#8212; Even more mature than above' ) . "</label><br />";
 					?>
 						<p class="description"><?php esc_html_e( 'If the local avatar is inappropriate for this site, Gravatar will be attempted.', 'simple-local-avatars' ); ?></p>
 					</fieldset></td>


### PR DESCRIPTION
### Description of the Change

Adding string translation method around each `$avatar_rating` when it is output in the `edit_user_profile()` method.

### Verification Process

- [x] Site language is set to English

![Screen Shot 2021-11-17 at 9 29 43 AM](https://user-images.githubusercontent.com/20844837/142219599-d72beb31-288d-4ee2-af54-688c5ae538f0.png)

- [x] User language is set to French

![Screen Shot 2021-11-17 at 9 29 37 AM](https://user-images.githubusercontent.com/20844837/142219739-c909410a-65fc-4001-a544-948e5f9dd915.png)

- [x] Rating strings are translated to French

![Screen Shot 2021-11-17 at 9 29 28 AM](https://user-images.githubusercontent.com/20844837/142219795-1db4ad69-3c5a-4607-b0f9-9fe63b17bf9c.png)


### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

[https://github.com/10up/simple-local-avatars/issues/88](https://github.com/10up/simple-local-avatars/issues/88)
