### PR TITLE
Add option to clear cache of user meta to remove image sizes that do not exist

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,73 +1,58 @@
-/* global ajaxurl, slaAdmin */
-(function ($) {
-    $(function () {
-        function slaAdminAction() {
-            const $sla = {
-                clearCache: $('#clear_cache_btn'),
-            };
+/* global ajaxurl, slaAdmin, jQuery */
+( function ( $ ) {
+	// Cache the button.
+	const $clearCacheBtn = $( '#clear_cache_btn' );
 
-            // Spinner button.
-            const spinnerButton = '<span class="spinner is-active"></span>';
+	// Spinner button.
+	const spinnerButton = '<span class="spinner is-active"></span>';
 
-            // Bind events.
-            const bindEvents = function () {
-                $sla.clearCache.on('click', function (e) {
-                    e.preventDefault();
-                    $sla.clearCache.addClass( 'disabled' );
-                    var data = {
-                        action: 'sla_clear_user_cache',
-                        nonce: slaAdmin.nonce,
-                    }
-                    $sla.clearCache.append(spinnerButton);
-                    processStep(1, data, $sla.clearCache);
-                });
-            };
+	// Bind events.
+	$clearCacheBtn.on( 'click', function ( e ) {
+		e.preventDefault();
+		$clearCacheBtn.addClass( 'disabled' );
+		$clearCacheBtn.append( spinnerButton );
+		var data = {
+			action: 'sla_clear_user_cache',
+			nonce: slaAdmin.nonce,
+		};
+		processStep( 1, data );
+	} );
 
-            /**
-             * Process steps.
-             *
-             * @param {Number} step For batch wise updates.
-             * @param {Object} data Data to pass to ajax request.
-             * @param {HTMLElement} el Spinner button.
-             */
-            function processStep(step, data, el) {
-                data.step = step;
-                $.ajax({
-                    url    : ajaxurl,
-                    dataType: 'json',
-                    data   : data,
-                    method : 'POST',
-                    success: function (response) {
-                        if (response.success) {
-                            if (response.data.step === 'done') {
-                                el.find('span').remove();
-                                $sla.clearCache.removeClass( 'disabled' );
-                            } else {
-                                processStep(parseInt(response.data.step, 10), data, el);
-                            }
-                            return false;
-                        } else {
-                            alert(slaAdmin.error);
-                            el.find('span').remove();
-                            $sla.clearCache.removeClass( 'disabled' );
-                        }
-                    },
-                    error  : function () {
-                        alert(slaAdmin.error);
-                        el.find('span').remove();
-                        $sla.clearCache.removeClass( 'disabled' );
-                    }
-                });
-            }
+	function removeSpinner() {
+		$clearCacheBtn.find( 'span' ).remove();
+		$clearCacheBtn.removeClass( 'disabled' );
+	}
 
-            const initializePage = function () {
-                bindEvents();
-            };
-
-            initializePage();
-        }
-
-        // Initialize page.
-        slaAdminAction();
-    });
-})(jQuery); // eslint-disable-line no-undef
+	/**
+	 * Process steps.
+	 *
+	 * @param {Number} step For batch wise updates.
+	 * @param {Object} data Data to pass to ajax request.
+	 */
+	function processStep( step, data ) {
+		data.step = step;
+		$.ajax( {
+			url: ajaxurl,
+			dataType: 'json',
+			data: data,
+			method: 'POST',
+			success: function ( response ) {
+				if ( response.success ) {
+					if ( response.data.step === 'done' ) {
+						removeSpinner();
+					} else {
+						processStep( parseInt( response.data.step, 10 ), data );
+					}
+					return false;
+				} else {
+					alert( slaAdmin.error );
+					removeSpinner();
+				}
+			},
+			error: function () {
+				alert( slaAdmin.error );
+				removeSpinner();
+			},
+		} );
+	}
+} )( jQuery );

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -2,9 +2,10 @@
 ( function ( $ ) {
 	// Cache the button.
 	const $clearCacheBtn = $( '#clear_cache_btn' );
+	const $clearCacheMessage = $( '#clear_cache_message' );
 
 	// Spinner button.
-	const spinnerButton = '<span class="spinner is-active"></span>';
+	const spinnerButton = '<span class="spinner is-active" style="margin-left:5px;margin-right:0;"></span>';
 
 	// Bind events.
 	$clearCacheBtn.on( 'click', function ( e ) {
@@ -39,18 +40,20 @@
 			success: function ( response ) {
 				if ( response.success ) {
 					if ( response.data.step === 'done' ) {
+						$clearCacheMessage.text( response.data.message );
 						removeSpinner();
 					} else {
+						$clearCacheMessage.text( response.data.message );
 						processStep( parseInt( response.data.step, 10 ), data );
 					}
 					return false;
 				} else {
-					alert( slaAdmin.error );
+					$clearCacheMessage.text( slaAdmin.error );
 					removeSpinner();
 				}
 			},
 			error: function () {
-				alert( slaAdmin.error );
+				$clearCacheMessage.text( slaAdmin.error );
 				removeSpinner();
 			},
 		} );

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,73 @@
+/* global ajaxurl, slaAdmin */
+(function ($) {
+    $(function () {
+        function slaAdminAction() {
+            const $sla = {
+                clearCache: $('#clear_cache_btn'),
+            };
+
+            // Spinner button.
+            const spinnerButton = '<span class="spinner is-active"></span>';
+
+            // Bind events.
+            const bindEvents = function () {
+                $sla.clearCache.on('click', function (e) {
+                    e.preventDefault();
+                    $sla.clearCache.addClass( 'disabled' );
+                    var data = {
+                        action: 'sla_clear_user_cache',
+                        nonce: slaAdmin.nonce,
+                    }
+                    $sla.clearCache.append(spinnerButton);
+                    processStep(1, data, $sla.clearCache);
+                });
+            };
+
+            /**
+             * Process steps.
+             *
+             * @param {Number} step For batch wise updates.
+             * @param {Object} data Data to pass to ajax request.
+             * @param {HTMLElement} el Spinner button.
+             */
+            function processStep(step, data, el) {
+                data.step = step;
+                $.ajax({
+                    url    : ajaxurl,
+                    dataType: 'json',
+                    data   : data,
+                    method : 'POST',
+                    success: function (response) {
+                        if (response.success) {
+                            if (response.data.step === 'done') {
+                                el.find('span').remove();
+                                $sla.clearCache.removeClass( 'disabled' );
+                            } else {
+                                processStep(parseInt(response.data.step, 10), data, el);
+                            }
+                            return false;
+                        } else {
+                            alert(slaAdmin.error);
+                            el.find('span').remove();
+                            $sla.clearCache.removeClass( 'disabled' );
+                        }
+                    },
+                    error  : function () {
+                        alert(slaAdmin.error);
+                        el.find('span').remove();
+                        $sla.clearCache.removeClass( 'disabled' );
+                    }
+                });
+            }
+
+            const initializePage = function () {
+                bindEvents();
+            };
+
+            initializePage();
+        }
+
+        // Initialize page.
+        slaAdminAction();
+    });
+})(jQuery); // eslint-disable-line no-undef

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -338,7 +338,8 @@ class Simple_Local_Avatars {
 			</label>
 		';
 		} else {
-            echo '<button id="clear_cache_btn" class="button delete" name="clear_cache_btn" >' . esc_html__( 'Clear cache', 'simple-local-avatars' ) . '</button>';
+			echo '<button id="clear_cache_btn" class="button delete" name="clear_cache_btn" >' . esc_html__( 'Clear cache', 'simple-local-avatars' ) . '</button><br/>';
+			echo '<span id="clear_cache_message" style="font-style:italic;font-size:15px;line-height:2;"></span>';
 		}
 	}
 
@@ -746,7 +747,6 @@ class Simple_Local_Avatars {
 		$users_per_page = 50;
 		$offset         = ( $step - 1 ) * $users_per_page;
 
-		$rows        = array();
 		$users_query = new \WP_User_Query(
 			array(
 				'fields' => array( 'ID' ),
@@ -755,29 +755,40 @@ class Simple_Local_Avatars {
 			)
 		);
 
+		// Total users in the site.
+		$total_users = $users_query->get_total();
+
 		// Get the users.
 		$users = $users_query->get_results();
 
 		if ( ! empty( $users ) ) {
 			foreach ( $users as $user ) {
 				$user_id       = $user->ID;
-				$rows[]        = $user_id;
 				$local_avatars = get_user_meta( $user_id, 'simple_local_avatar', true );
 				$this->clear_user_avatar_cache( $local_avatars, $user_id, $local_avatars['media_id'] ?? '' );
 			}
-		}
 
-		if ( ! empty( $rows ) ) {
 			wp_send_json_success(
 				array(
-					'step' => $step + 1,
+					'step'    => $step + 1,
+					'message' => sprintf(
+					/* translators: 1: Offset, 2: Total users  */
+						esc_html__( 'Processing %1$s/%2$s users...', 'simple-local-avatars' ),
+						$offset,
+						$total_users
+					),
 				)
 			);
 		}
 
 		wp_send_json_success(
 			array(
-				'step' => 'done',
+				'step'    => 'done',
+				'message' => sprintf(
+				/* translators: %s Total users */
+					esc_html__( 'Completed clearing cache for all %s user(s) avatars.', 'simple-local-avatars' ),
+					$total_users
+				),
 			)
 		);
 	}

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -339,7 +339,7 @@ class Simple_Local_Avatars {
 		';
 		} else {
 			echo '<button id="clear_cache_btn" class="button delete" name="clear_cache_btn" >' . esc_html__( 'Clear cache', 'simple-local-avatars' ) . '</button><br/>';
-			echo '<span id="clear_cache_message" style="font-style:italic;font-size:15px;line-height:2;"></span>';
+			echo '<span id="clear_cache_message" style="font-style:italic;font-size:14px;line-height:2;"></span>';
 		}
 	}
 

--- a/simple-local-avatars.php
+++ b/simple-local-avatars.php
@@ -15,6 +15,10 @@
 
 require_once dirname( __FILE__ ) . '/includes/class-simple-local-avatars.php';
 
+// Global constants.
+define( 'SLA_VERSION', '2.2.0' );
+define( 'SLA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
 /**
  * Init the plugin.
  */


### PR DESCRIPTION
### Description of the Change

- Adds a `Clear Cache` button in  `Settings` -> `Discussion`, which updates the user meta to remove images that don't exist.

### Alternate Designs

N/A

### Benefits

- Fixes issue with broken avatar links after media regeneration which may delete the images.

### Possible Drawbacks

N/A

### Verification Process

- Set an avatar for your profile
- Install `Regenerate Thumbnails` plugin
- Use `Tools` -> `Regenerate Thumbnails`, select `Delete thumbnail files for old unregistered sizes in order to free up server space. This may result in broken images in your posts and pages.` checkbox and regenerate the thumbnails.
- This will make the avatar images broken, go to `Settings` -> `Discussion` and use the `Clear Cache` to fix the issue.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Fixs https://github.com/10up/simple-local-avatars/issues/31

### Changelog Entry

- Add `Clear Cache` button to fix broken avatar images after thumbnail regeneration.