### PR TITLE
Fix/116 Rest of the `admin.js` content migrated

### DIFF
--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -211,6 +211,9 @@ jQuery(document).ready(function ($) {
 	// Cache the button.
 	const $clearCacheBtn = $( '#clear_cache_btn' );
 	const $clearCacheMessage = $( '#clear_cache_message' );
+	const $simpleLocalAvatarDefault = $('#simple-local-avatar-default');
+	const $simpleLocalAvatarFileUrl = $('#simple-local-avatar-file-url');
+	const $simpleLocalAvatarFileId = $('#simple-local-avatar-file-id');
 
 	// Spinner button.
 	const spinnerButton = '<span class="spinner is-active" style="margin-left:5px;margin-right:0;"></span>';
@@ -265,6 +268,46 @@ jQuery(document).ready(function ($) {
 				removeSpinner();
 			},
 		} );
+	}
+
+	/**
+	 * Default avatar upload field listener in Settings -> Discussions.
+	 */
+	$simpleLocalAvatarDefault.click(function(e) {
+		e.preventDefault();
+		var _this = $(this);
+		var image = wp.media({
+			title: slaAdmin.insertMediaTitle,
+			multiple: false,
+			library : {
+				type : 'image',
+			}
+		}).open()
+			.on('select', function(e){
+				// This will return the selected image from the Media Uploader, the result is an object
+				var uploaded_image = image.state().get('selection').first();
+				uploaded_image = uploaded_image.toJSON();
+				var avatar_preview = uploaded_image?.sizes?.thumbnail?.url;
+				if ( 'undefined' === typeof avatar_preview ) {
+					avatar_preview = uploaded_image.url;
+				}
+				var simpleDefaultAvatarImg = _this.parent().find('img.avatar');
+				simpleDefaultAvatarImg.show();
+				simpleDefaultAvatarImg.attr( 'src', avatar_preview );
+				simpleDefaultAvatarImg.attr( 'srcset', avatar_preview );
+				$simpleLocalAvatarFileUrl.val(avatar_preview);
+				$simpleLocalAvatarFileId.val(uploaded_image.id);
+			});
+	});
+
+	if ( $simpleLocalAvatarFileUrl.length && $simpleLocalAvatarFileUrl.val() !== '' ) {
+		var $simpleDefaultAvatarImg = $simpleLocalAvatarFileUrl.parent().find('img.avatar');
+		$simpleDefaultAvatarImg.attr('src', $simpleLocalAvatarFileUrl.val());
+		$simpleDefaultAvatarImg.attr('srcset', $simpleLocalAvatarFileUrl.val());
+	}
+
+	if ( '' === $simpleLocalAvatarFileId.val() ) {
+		$simpleLocalAvatarFileId.parent().find('img.avatar').hide();
 	}
 });
 

--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -277,7 +277,7 @@ jQuery(document).ready(function ($) {
 		e.preventDefault();
 		var _this = $(this);
 		var image = wp.media({
-			title: slaAdmin.insertMediaTitle,
+			title: i10n_SimpleLocalAvatars.insertMediaTitle,
 			multiple: false,
 			library : {
 				type : 'image',

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -650,7 +650,6 @@ class Simple_Local_Avatars {
 			'i10n_SimpleLocalAvatars',
 			array(
 				'user_id'                         => $user_id,
-				'insertMediaTitle'                => __( 'Choose an Avatar', 'simple-local-avatars' ),
 				'insertIntoPost'                  => __( 'Set as avatar', 'simple-local-avatars' ),
 				'selectCrop'                      => __( 'Select avatar and Crop', 'simple-local-avatars' ),
 				'deleteNonce'                     => $this->remove_nonce,
@@ -658,6 +657,7 @@ class Simple_Local_Avatars {
 				'mediaNonce'                      => wp_create_nonce( 'assign_simple_local_avatar_nonce' ),
 				'migrateFromWpUserAvatarNonce'    => wp_create_nonce( 'migrate_from_wp_user_avatar_nonce' ),
 				'clearCacheError'                 => esc_html__( 'Something went wrong while clearing cache, please try again.', 'simple-local-avatars' ),
+				'insertMediaTitle'                => esc_html__( 'Choose default avatar', 'simple-local-avatars' ),
 				'migrateFromWpUserAvatarSuccess'  => __( 'Number of avatars successfully migrated from WP User Avatar', 'simple-local-avatars' ),
 				'migrateFromWpUserAvatarFailure'  => __( 'No avatars were migrated from WP User Avatar.', 'simple-local-avatars' ),
 				'migrateFromWpUserAvatarProgress' => __( 'Migration in progress.', 'simple-local-avatars' ),


### PR DESCRIPTION
### Description of the Change

Somehow the `admin.js` file's content is not fully migrated in the `simple-local-avatars.js` file in #118. This PR moves the content completely. The missed portion is from the #96.

### Verification Process

Build the project and make sure the "Choose Default Avatar" works in the Settings > Discussion.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

n/a as it this PR is a part of #118.

### Credits

Props @faisal-alvi @peterwilsoncc
