### PR TITLE
Fix thumbnail urls for network configured avatars

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -358,7 +358,7 @@ class Simple_Local_Avatars {
 							$dest_file_url = '';
 							if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
 								$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
-							} else if ( is_multisite() && false !== strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
+							} else if ( is_multisite() && strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
 								$dest_file_url = str_replace( ABSPATH . 'wp-content/uploads', network_site_url( '/wp-content/uploads' ), $dest_file );
 							}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -356,7 +356,7 @@ class Simple_Local_Avatars {
 						if ( ! is_wp_error( $saved ) ) {
 							// Transform the destination file path into URL.
 							$dest_file_url = '';
-							if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
+							if ( strpos( $dest_file, $upload_path['basedir'] ) ) {
 								$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
 							} else if ( is_multisite() && strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
 								$dest_file_url = str_replace( ABSPATH . 'wp-content/uploads', network_site_url( '/wp-content/uploads' ), $dest_file );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -356,9 +356,9 @@ class Simple_Local_Avatars {
 						if ( ! is_wp_error( $saved ) ) {
 							// Transform the destination file path into URL.
 							$dest_file_url = '';
-							if ( strpos( $dest_file, $upload_path['basedir'] ) ) {
+							if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
 								$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
-							} else if ( is_multisite() && strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
+							} else if ( is_multisite() && false !== strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
 								$dest_file_url = str_replace( ABSPATH . 'wp-content/uploads', network_site_url( '/wp-content/uploads' ), $dest_file );
 							}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -354,7 +354,15 @@ class Simple_Local_Avatars {
 						$dest_file = $editor->generate_filename();
 						$saved     = $editor->save( $dest_file );
 						if ( ! is_wp_error( $saved ) ) {
-							$local_avatars[ $size ] = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
+							// Transform the destination file path into URl.
+							$dest_file_url = '';
+							if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
+								$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
+							} else if ( is_multisite() && false !== strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
+								$dest_file_url = str_replace( ABSPATH . 'wp-content/uploads', network_site_url( '/wp-content/uploads' ), $dest_file );
+							}
+
+							$local_avatars[ $size ] = $dest_file_url;
 						}
 					}
 				}
@@ -1306,10 +1314,10 @@ class Simple_Local_Avatars {
 			update_option( 'simple_local_avatar_default', $file_id );
 		}
 	}
-  
+
 	/**
 	 * Migrate the user's avatar data from WP User Avatar/ProfilePress
-	 * 
+	 *
 	 * This function creates a new option in the wp_options table to store the processed user IDs
 	 * so that we can run this command multiple times without processing the same user over and over again.
 	 *

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -354,7 +354,7 @@ class Simple_Local_Avatars {
 						$dest_file = $editor->generate_filename();
 						$saved     = $editor->save( $dest_file );
 						if ( ! is_wp_error( $saved ) ) {
-							// Transform the destination file path into URl.
+							// Transform the destination file path into URL.
 							$dest_file_url = '';
 							if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
 								$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );


### PR DESCRIPTION
### Description of the Change

After generating a non-existent thumbnail size for an avatar in the `Simple_Local_Avatars::get_simple_local_avatar_url()@L336` method, the current logic transforms the destination file path to a URL by replacing the current blog `$upload_path['basedir']` with `$upload_path['baseurl']`. 

This works fine for all situations except when avatars are configured at the network level, since those avatars use the `uploads` directory (`wp-content/uploads`) as a basedir, not the site-specific directory (e.g. `wp-content/uploads/sites/5/`). This is why the destination file path doesn't get converted into a URL, and the plugin ends up caching the full path for that thumbnail size.

My solution is to test for this specific case, and properly transform the path into a URL.

Closes #124 

### Alternate Designs

Not the case.

### Possible Drawbacks

None that I can imagine.

### Verification Process

I have checked both with our themes (@pixelgrade) and with the standard core themes. Since the logic is additional to the existing one, without modifying the existing logic, the changes are safe.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

Fixed - Broken avatar URLs for network-configured shared avatars with non-standard thumbnail sizes.

### Credits

Props @vladolaru
