### PR TITLE
Try adding alt text when rendering local avatars

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -275,7 +275,7 @@ class Simple_Local_Avatars {
 	/**
 	 * Get a user ID from certain possible values.
 	 *
-	 * @since 2.4.1
+	 * @since 2.5.0
 	 *
 	 * @param mixed $id_or_email The Gravatar to retrieve. Accepts a user ID, Gravatar MD5 hash,
 	 *                           user email, WP_User object, WP_Post object, or WP_Comment object.
@@ -397,7 +397,7 @@ class Simple_Local_Avatars {
 	/**
 	 * Get local avatar alt text.
 	 *
-	 * @since 2.4.1
+	 * @since 2.5.0
 	 *
 	 * @param mixed $id_or_email The Gravatar to retrieve. Accepts a user ID, Gravatar MD5 hash,
 	 *                           user email, WP_User object, WP_Post object, or WP_Comment object.

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -171,8 +171,13 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		       ->with( 'avatar_rating' )
 		       ->andReturn( false );
 
+		WP_Mock::userFunction( 'get_post_meta' )
+		       ->with( 101, '_wp_attachment_image_alt', true )
+		       ->andReturn( 'Custom alt text' );
+
 		$avatar_data = $this->instance->get_avatar_data( [ 'size' => 96 ], 1 );
 		$this->assertEquals( 'https://example.com/avatar-96x96.png', $avatar_data['url'] );
+		$this->assertEquals( 'Custom alt text', $avatar_data['alt'] );
 	}
 
 	public function test_get_simple_local_avatar_url_with_empty_id() {
@@ -198,6 +203,32 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 
 	public function test_get_simple_local_avatar_url() {
 		$this->assertEquals( 'https://example.com/avatar-96x96.png', $this->instance->get_simple_local_avatar_url( 1, 96 ) );
+	}
+
+	public function test_get_simple_local_avatar_alt() {
+		WP_Mock::userFunction( 'get_post_meta' )
+		       ->with( 101, '_wp_attachment_image_alt', true )
+		       ->andReturn( 'Custom alt text' );
+
+		$this->assertEquals( 'Custom alt text', $this->instance->get_simple_local_avatar_alt( 1 ) );
+	}
+
+	public function test_get_simple_local_avatar_alt_with_override() {
+		WP_Mock::userFunction( 'get_post_meta' )
+		       ->with( 101, '_wp_attachment_image_alt', true )
+		       ->andReturn( 'Custom alt text' );
+
+		$avatar_data = $this->instance->get_avatar_data( [ 'size' => 96, 'alt' => 'Override alt' ], 1 );
+		$this->assertEquals( 'Override alt', $avatar_data['alt'] );
+	}
+
+	public function test_get_simple_local_avatar_alt_with_no_override() {
+		WP_Mock::userFunction( 'get_post_meta' )
+		       ->with( 101, '_wp_attachment_image_alt', true )
+		       ->andReturn( '' );
+
+		$avatar_data = $this->instance->get_avatar_data( [ 'size' => 96, 'alt' => '' ], 1 );
+		$this->assertEquals( '', $avatar_data['alt'] );
 	}
 
 	public function test_admin_init() {


### PR DESCRIPTION
### Description of the Change

As mentioned in #126, it doesn't appear the alt text saved with an attachment is ever used when rendering a local avatar. If someone passes in some custom alt text (for instance, using the 4th argument of `get_avatar`) that is then used as the alt text for the image. But if that argument isn't passed in but the attachment we are rendering has alt text assigned to it, we should use that for the alt text argument.

This PR fixes that by adding a check that runs if a local avatar is found AND no custom alt text has been passed in. It then pulls the alt text from the underlying attachment object which will be stored in post meta (if it exists, otherwise just an empty string).

I also added a new method used to get the user ID, to avoid having duplicate code between the existing `get_simple_local_avatar_url` method and the new `get_simple_local_avatar_alt` method. 

Closes #126 

### Alternate Designs

Right now we default to using the alt text that is passed in and then fallback to the alt text assigned to an image. I think that's the right approach but we could flip those, so the alt text saved with an image would take precedence.

### Possible Drawbacks

None

### Verification Process

1. Upload a new image
2. Add alt text to this image
3. Set this image as your local avatar
4. Publish a new post with that user
5. Using a theme that renders an author section (like Twenty Twenty One) view the front-end of that post
6. Inspect the author image and note the alt text being used
7. For a second test, add a call to `get_avatar` and pass in the 4th argument for the alt text
8. Inspect the source again and note the alt text now comes from that function and not the image

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Added - If an image used for a local avatar has alt text assigned, ensure that alt text is used when rendering the image

### Credits

Props @dkotter, @pixelloop