### PR TITLE
Fix/123 `HTTP_REFERER` is checked if set or not

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -80,7 +80,7 @@ class Simple_Local_Avatars {
 			&& (
 				( // And either an ajax request not in the network admin.
 					defined( 'DOING_AJAX' ) && DOING_AJAX
-					&& ! preg_match( '#^' . network_admin_url() . '#i', $_SERVER['HTTP_REFERER'] )
+					&& isset( $_SERVER['HTTP_REFERER'] ) && ! preg_match( '#^' . network_admin_url() . '#i', $_SERVER['HTTP_REFERER'] )
 				)
 				||
 				( // Or normal request not in the network admin.


### PR DESCRIPTION
### Description of the Change

This PR simply adds an `isset` check for the `$_SERVER['HTTP_REFERER']` to prevent PHP warnings.

<!-- Enter any applicable Issues here. Example: -->
Closes #123

### Verification Process

Not required, though a quick check of the plugin functionalities would be appreciated.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Fixed - `HTTP_REFERER` is null and causing php warning.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @alireza-salehi @faisal-alvi 
