### PR TITLE
Enhancement/128 ”Skip cropping” + “Free cropping area” added!

### DIFF
--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -31,31 +31,11 @@ jQuery(document).ready(function ($) {
 		const cropControl = {
 			id: 'control-id',
 			params: {
-				flex_width: false, // set to true if the width of the cropped image can be different to the width defined here
-				flex_height: false, // set to true if the height of the cropped image can be different to the height defined here
+				flex_width: true, // set to true if the width of the cropped image can be different to the width defined here
+				flex_height: true, // set to true if the height of the cropped image can be different to the height defined here
 				width: 200, // set the desired width of the destination image here
 				height: 200, // set the desired height of the destination image here
 			},
-		};
-
-		/**
-		 * Return whether the image must be cropped, based on required dimensions.
-		 *
-		 * @param {boolean} flexW
-		 * @param {boolean} flexH
-		 * @param {number}  distW
-		 * @param {number}  distH
-		 * @param {number}  imgW
-		 * @param {number}  imgH
-		 * @returns {boolean}
-		 */
-		cropControl.mustBeCropped = function (flexW, flexH, distW, distH, imgW, imgH) {
-			// Skip cropping if the image matches the crop dimension.
-			if (imgW === distW && imgH === distH) {
-				return false;
-			}
-
-			return true;
 		};
 
 		/**
@@ -354,10 +334,8 @@ function simple_local_avatar_calculate_image_select_options(attachment, controll
 
 	const ratio = xInit / yInit;
 
-	controller.set(
-		'canSkipCrop',
-		!control.mustBeCropped(false, false, xInit, yInit, realWidth, realHeight),
-	);
+    // Enable skip cropping button.
+    controller.set('canSkipCrop', true);
 
 	const xImg = xInit;
 	const yImg = yInit;
@@ -386,7 +364,6 @@ function simple_local_avatar_calculate_image_select_options(attachment, controll
 		y1,
 		x2: xInit + x1,
 		y2: yInit + y1,
-		aspectRatio: `${xInit}:${yInit}`,
 	};
 }
 
@@ -440,7 +417,7 @@ function simple_local_avatar_set_image_from_url(url, attachmentId, width, height
 }
 
 /**
- * Set the avatar image, once it is selected from the media library. 
+ * Set the avatar image, once it is selected from the media library.
  *
  * @param {object} attachment
  */

--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -334,8 +334,8 @@ function simple_local_avatar_calculate_image_select_options(attachment, controll
 
 	const ratio = xInit / yInit;
 
-    // Enable skip cropping button.
-    controller.set('canSkipCrop', true);
+	// Enable skip cropping button.
+	controller.set('canSkipCrop', true);
 
 	const xImg = xInit;
 	const yImg = yInit;


### PR DESCRIPTION
### Description of the Change

- This PR introduces a new button “Skip cropping”, similarly to how the site icon is handled.
- And, the “Free cropping” area feature for avatar crops.

<!-- Enter any applicable Issues here. Example: -->
Closes #128

### Alternate Designs

<img width="283" alt="Screen Shot 2022-05-13 at 9 45 08 AM" src="https://user-images.githubusercontent.com/916738/168320142-5de0af72-1928-4d64-80f1-6908978462b5.png">

### Possible Drawbacks

No more square restrictions in the crop, so the users who want it to be strict "Square", may have to manually crop the image and try to make it square. :|

### Verification Process

1. Build the project `npm run build`.
2. Visit Users > Profile.
3. Click the “Choose from Media Library” button.
4. Select/Upload any image.
5. Click the “Select avatar and Crop” button.
6. Try to change the cropping area to any size and shape.
7. At the bottom right of the popup, see the “Skip cropping” button. Try using it.
8. Also, try cropping various shapes and see if that works.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

> Added - “Skip cropping” button added.
> Added - Free Cropping area introduced, no more strict squares!

### Credits
Props @dkotter @faisal-alvi @cadic 
