### PR TITLE
bbPress - make sure the button to remove the avatar works

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -118,6 +118,8 @@ class Simple_Local_Avatars {
 		add_action( 'wp_ajax_remove_simple_local_avatar', array( $this, 'action_remove_simple_local_avatar' ) );
 		add_action( 'user_edit_form_tag', array( $this, 'user_edit_form_tag' ) );
 
+		add_action( 'init', array( $this, 'front_end_remove_avatar' ) );
+
 		add_action( 'rest_api_init', array( $this, 'register_rest_fields' ) );
 
 		add_action( 'wp_ajax_migrate_from_wp_user_avatar', array( $this, 'ajax_migrate_from_wp_user_avatar' ) );
@@ -1524,4 +1526,15 @@ class Simple_Local_Avatars {
 			)
 		);
 	}
+
+	function front_end_remove_avatar() {
+		// TODO: This is missing nonce, so we only allow you to remove your own avatar
+		if( !empty($_GET['action']) && $_GET['action'] == 'remove-simple-local-avatar' && !empty($_GET['user_id']) ) {
+			$user_id = $_GET['user_id'];
+			if( get_current_user_id() == $user_id ) {
+				$this->avatar_delete( $user_id );
+			}
+		}
+
+	} 
 }


### PR DESCRIPTION
### Description of the Change

When the user avatar is stored, the "Delete local avatar" button on bbPress edit page does not work.

The button is actually a simple link with the `user_id={ID}` and and `action=remove-simple-local-avatar`.

This improvement makes sure it's processed for bbPress edit profile page.

### Alternate Designs

It might be better to adjust admin_enqueue_scripts() to work on bbPress edit profile page, it would also use the nonce that way.

### Possible Drawbacks

It's missing the nonce security.

### Verification Process

The "Delete local avatar" on the bbPress profile editing is now able to delete the stored avatar.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Changelog Entry

Fixed - avatar removal on bbPress profile edit page

### Credits

Props @foliovision
