### PR TITLE
Fix/135 Re-adding "Square" Crop ability

### DIFF
--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -364,6 +364,7 @@ function simple_local_avatar_calculate_image_select_options(attachment, controll
 		y1,
 		x2: xInit + x1,
 		y2: yInit + y1,
+		aspectRatio: `${xInit}:${yInit}`,
 	};
 }
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -99,6 +99,7 @@ class Simple_Local_Avatars {
 	 * Register actions and filters.
 	 */
 	public function add_hooks() {
+		global $pagenow;
 
 		add_filter( 'plugin_action_links_' . SLA_PLUGIN_BASENAME, array( $this, 'plugin_filter_action_links' ) );
 
@@ -133,6 +134,14 @@ class Simple_Local_Avatars {
 
 		add_filter( 'avatar_defaults', array( $this, 'add_avatar_default_field' ) );
 		add_action( 'wpmu_new_blog', array( $this, 'set_defaults' ) );
+
+		if ( 'profile.php' === $pagenow ) {
+			add_filter( 'media_view_strings', function ( $strings ) {
+				$strings['skipCropping'] = esc_html__( 'Default Crop', 'simple-local-avatars' );
+
+				return $strings;
+			}, 10, 1 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required.  Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

* This PR removes the "freeform" ability and re-adds the "sure" crop ability (which was removed in #130).
* Also updates the button name from "Skip Crop" to "Default Crop" only on the edit profile page.

<!-- Enter any applicable Issues here. Example: -->
Closes #135

### Alternate Designs

n/a

### Possible Drawbacks

Maybe in the future, we get some users wanting the freeform crop ability.

### Verification Process

1. Edit your profile.
2. Set an avatar.
3. See, you are forced to stick with the Square form while cropping an avatar.
4. Also check if the button name from "Skip Crop" to "Default Crop" is only changed on the edit profile page, not any other page like when selecting the site icon in the customizer (`wp-admin/customize.php?return=%2Fwp-admin%2Fprofile.php`), the button name should be "Skip Crop".

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Added - Re-added the Square crop ability.

### Credits

Props @dkotter @dinhtungdu @faisal-alvi 
