### PR TITLE
Enhancement/140 Bump WordPress and PHP minimums

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#4.9'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '7.4'
           tools: composer:v2
           coverage: none
 

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   php_compatibility:
-    name: PHP minimum 5.6
+    name: PHP minimum 7.4
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +21,7 @@ jobs:
       - name: Set PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.2
+          php-version: 7.4
           tools: composer:v2
           coverage: none
 
@@ -29,4 +29,4 @@ jobs:
         run: composer update -W
 
       - name: Check PHP Compatibility
-        run: vendor/bin/phpcs simple-local-avatars.php includes/ --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6-
+        run: vendor/bin/phpcs simple-local-avatars.php includes/ --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We claim to support from 5.6+ but WP Mock only supports 7.1+
-        # Also an issue with WP Mock not working on PHPUnit 9.5+, which PHP 7.3+ needs.
-        # php: [ '5.6', '7.0', '7.4', '8.0', '8.1' ]
-        php: [ '7.1', '7.2' ]
+        php: [ '7.4', '8.0', '8.1' ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,28 +10,13 @@ on:
       - develop
 
 jobs:
-#  test_wpa:
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#    - name: Checkout
-#      uses: actions/checkout@v2
-#    - name: Set PHP version
-#      uses: shivammathur/setup-php@v1
-#      with:
-#        php-version: '7.2'
-#        coverage: none
-#
-#    - name: Install dependencies
-#      run: composer install
-
   phpunit:
     name: ${{ matrix.php }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.1', '7.2' ]
+        php: [ '7.4', '8.0' ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4', '8.0', '8.1' ]
+        php: [ '7.1', '7.2' ]
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "source": "https://github.com/10up/simple-local-avatars"
   },
   "require": {
-    "php": ">=7.4"
+    "php": ">=7.1"
   },
   "require-dev": {
     "10up/phpcs-composer": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "source": "https://github.com/10up/simple-local-avatars"
   },
   "require": {
-    "php": ">=5.6"
+    "php": ">=7.4"
   },
   "require-dev": {
     "10up/phpcs-composer": "dev-master",
@@ -28,12 +28,12 @@
   },
   "scripts": {
     "lint": [
-      "phpcs . --runtime-set testVersion 5.6-"
+      "phpcs . --runtime-set testVersion 7.4-"
     ],
     "lint-fix": [
       "phpcbf ."
     ],
-    "phpcs:compat": "vendor/bin/phpcs simple-local-avatars.php includes --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6-"
+    "phpcs:compat": "vendor/bin/phpcs simple-local-avatars.php includes --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-"
   },
   "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "source": "https://github.com/10up/simple-local-avatars"
   },
   "require": {
-    "php": ">=7.1"
+    "php": ">=7.4"
   },
   "require-dev": {
     "10up/phpcs-composer": "dev-master",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,20 @@
-<phpunit
-	bootstrap="tests/phpunit/bootstrap.php"
-	backupGlobals="false"
-	processIsolation="false"
-	colors="false">
-	<testsuites>
-		<testsuite name="Simple Local Avatars">
-			<directory suffix="Test.php">./tests/phpunit</directory>
-			<exclude>tests/phpunit/multisite</exclude>
-		</testsuite>
-	</testsuites>
-	<filter>
-		<whitelist>
-			<directory suffix=".php">includes</directory>
-			<exclude></exclude>
-		</whitelist>
-	</filter>
-	<php>
-		<ini name="error_reporting" value="32767" />
-		<ini name="display_errors" value="1" />
-		<ini name="display_startup_errors" value="1" />
-	</php>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/phpunit/bootstrap.php" backupGlobals="false" processIsolation="false" colors="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">includes</directory>
+    </include>
+    <exclude/>
+  </coverage>
+  <testsuites>
+    <testsuite name="Simple Local Avatars">
+      <directory suffix="Test.php">./tests/phpunit</directory>
+      <exclude>tests/phpunit/multisite</exclude>
+    </testsuite>
+  </testsuites>
+  <php>
+    <ini name="error_reporting" value="32767"/>
+    <ini name="display_errors" value="1"/>
+    <ini name="display_startup_errors" value="1"/>
+  </php>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors:      jakemgold, 10up, thinkoomph, jeffpaul, faisal03
 Donate link:       https://10up.com/plugins/simple-local-avatars-wordpress/
 Tags:              avatar, gravatar, user photos, users, profile
-Requires at least: 4.6
+Requires at least: 5.7
 Tested up to:      6.0
-Requires PHP:      5.6
+Requires PHP:      7.4
 Stable tag:        2.5.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-local-avatars.php
+++ b/simple-local-avatars.php
@@ -4,8 +4,8 @@
  * Plugin URI:        https://10up.com/plugins/simple-local-avatars-wordpress/
  * Description:       Adds an avatar upload field to user profiles. Generates requested sizes on demand, just like Gravatar! Simple and lightweight.
  * Version:           2.5.0
- * Requires at least: 4.6
- * Requires PHP:      5.6
+ * Requires at least: 5.7
+ * Requires PHP:      7.4
  * Author:            Jake Goldman, 10up
  * Author URI:        https://10up.com
  * License:           GPLv2 or later

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -106,12 +106,12 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 	}
 
 	public function test_is_network() {
-		\WP_Mock::userFunction( 'get_site_option', [
+		WP_Mock::userFunction( 'get_site_option', [
 			'args'   => [ 'active_sitewide_plugins', [] ],
 			'return' => [],
 			'times'  => 1,
 		] );
-		\WP_Mock::userFunction( 'is_multisite', [
+		WP_Mock::userFunction( 'is_multisite', [
 			'return' => false,
 			'times'  => 1,
 		] );

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -4,7 +4,7 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 	private $instance;
 
 	public function setUp(): void {
-		parent::setUp();
+		\WP_Mock::setUp();
 
 		$this->instance = Mockery::mock( 'Simple_Local_Avatars' )->makePartial();
 
@@ -75,7 +75,7 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		$this->addToAssertionCount(
 			Mockery::getContainer()->mockery_getExpectationCount()
 		);
-		parent::tearDown();
+		\WP_Mock::tearDown();
 	}
 
 	public function test_add_hooks() {

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -106,12 +106,12 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 	}
 
 	public function test_is_network() {
-		WP_Mock::userFunction( 'get_site_option', [
+		\WP_Mock::userFunction( 'get_site_option', [
 			'args'   => [ 'active_sitewide_plugins', [] ],
 			'return' => [],
 			'times'  => 1,
 		] );
-		WP_Mock::userFunction( 'is_multisite', [
+		\WP_Mock::userFunction( 'is_multisite', [
 			'return' => false,
 			'times'  => 1,
 		] );

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -165,7 +165,7 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		$this->assertNotEmpty( $action_links );
 
 		$this->assertArrayHasKey( 'settings', $action_links );
-		$this->assertContains( 'options-discussion.php', $action_links['settings'] );
+		$this->assertStringContainsString( 'options-discussion.php', $action_links['settings'] );
 	}
 
 	public function test_get_avatar_data() {
@@ -301,11 +301,11 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		WP_Mock::userFunction( 'checked' )
 		       ->andReturn( 'checked' );
 
-		$expected = '<label for="simple-local-avatars-shared"><input type="checkbox" name="simple_local_avatars[shared]" id="simple-local-avatars-shared" value="1" checked />This is a description.</label>';
-
-		$this->expectOutputString( $expected );
-
+		ob_start();
 		$this->instance->avatar_settings_field( $args );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'This is a description.', $output );
 	}
 
 	public function test_edit_user_profile() {
@@ -329,11 +329,11 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		$profileuser     = new stdClass();
 		$profileuser->ID = 1;
 
-		$expected = '<div id="simple-local-avatar-section"><h3>Avatar</h3><table class="form-table"><tr class="upload-avatar-row"><th scope="row"><label for="simple-local-avatar">Upload Avatar</label></th><td style="width: 50px;" id="simple-local-avatar-photo"><img src="test-image-user-avatar"/></td><td><p style="display: inline-block; width: 26em;"><span class="description">Choose an image from your computer:</span><br /><input type="file" name="simple-local-avatar" id="simple-local-avatar" class="standard-text" /><span class="spinner" id="simple-local-avatar-spinner"></span></p><p><a href="" class="button item-delete submitdelete deletion" id="simple-local-avatar-remove"  style="display:none;">Delete local avatar</a></p></td></tr><tr class="ratings-row"><th scope="row">Rating</th><td colspan="2"><fieldset id="simple-local-avatar-ratings" ><legend class="screen-reader-text"><span>Rating</span></legend><label><input type=\'radio\' name=\'simple_local_avatar_rating\' value=\'G\' />G &#8212; Suitable for all audiences</label><br /><label><input type=\'radio\' name=\'simple_local_avatar_rating\' value=\'PG\' />PG &#8212; Possibly offensive, usually for audiences 13 and above</label><br /><label><input type=\'radio\' name=\'simple_local_avatar_rating\' value=\'R\' />R &#8212; Intended for adult audiences above 17</label><br /><label><input type=\'radio\' name=\'simple_local_avatar_rating\' value=\'X\' />X &#8212; Even more mature than above</label><br /><p class="description">If the local avatar is inappropriate for this site, Gravatar will be attempted.</p></fieldset></td></tr></table></div>';
-
-		$this->expectOutputString( $expected );
-
+		ob_start();
 		$this->instance->edit_user_profile( $profileuser );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Choose an image from your computer', $output );
 	}
 
 	public function test_assign_new_user_avatar() {

--- a/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
+++ b/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
@@ -4,7 +4,7 @@ class SimpleLocalAvatarsNetworkTest extends \WP_Mock\Tools\TestCase {
 	private $instance;
 
 	public function setUp(): void {
-		parent::setUp();
+		\WP_Mock::setUp();
 
 		$this->instance = Mockery::mock( 'Simple_Local_Avatars' )->makePartial();
 


### PR DESCRIPTION
### Description of the Change
Bumped the minimum WordPress and PHP minimums.
* WordPress to 5.7
* PHP to 7.4

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #140.

### How to test the Change
* Check if the plugin is working as expected.
* Check the Github Actions working without fails.

### Changelog Entry
> Changed - Bump min WordPress to 5.7 and min PHP to 7.4

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @vikrampm1 @faisal-alvi @cadic 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
