### PR TITLE
Ensure default avatars get alt text

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -426,17 +426,36 @@ class Simple_Local_Avatars {
 	public function get_simple_local_avatar_alt( $id_or_email ) {
 		$user_id = $this->get_user_id( $id_or_email );
 
+		/**
+		 * Filter the default avatar alt text.
+		 *
+		 * @param string $alt Default alt text.
+		 * @return string
+		 */
+		$default_alt = apply_filters( 'simple_local_avatars_default_alt', __( 'Avatar photo', 'simple-local-avatars' ) );
+
 		if ( empty( $user_id ) ) {
-			return '';
+			return $default_alt;
 		}
 
 		// Fetch local avatar from meta and make sure we have a media ID.
 		$local_avatars = get_user_meta( $user_id, 'simple_local_avatar', true );
 		if ( empty( $local_avatars['media_id'] ) ) {
-			return '';
+			$alt = '';
+			// If no avatar is set, check if we are using a default avatar with alt text.
+			if ( 'simple_local_avatar' === get_option( 'avatar_default' ) ) {
+				$default_avatar_id = get_option( 'simple_local_avatar_default', '' );
+				if ( ! empty( $default_avatar_id ) ) {
+					$alt = get_post_meta( $default_avatar_id, '_wp_attachment_image_alt', true );
+				}
+			}
+
+			return $alt ? $alt : $default_alt;
 		}
 
-		return esc_attr( get_post_meta( $local_avatars['media_id'], '_wp_attachment_image_alt', true ) );
+		$alt = get_post_meta( $local_avatars['media_id'], '_wp_attachment_image_alt', true );
+
+		return $alt ? $alt : $default_alt;
 	}
 
 	/**

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -230,7 +230,39 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		       ->andReturn( '' );
 
 		$avatar_data = $this->instance->get_avatar_data( [ 'size' => 96, 'alt' => '' ], 1 );
-		$this->assertEquals( '', $avatar_data['alt'] );
+		$this->assertEquals( 'Avatar photo', $avatar_data['alt'] );
+	}
+
+	public function test_get_simple_local_avatar_alt_with_default_avatar_without_alt() {
+		WP_Mock::userFunction( 'get_user_meta' )
+		       ->with( 1, 'simple_local_avatar', true )
+		       ->andReturn( [] );
+
+		WP_Mock::userFunction( 'get_option' )
+		       ->with( 'avatar_default' )
+		       ->andReturn( 'mystery' );
+
+		$this->assertEquals( 'Avatar photo', $this->instance->get_simple_local_avatar_alt( 1 ) );
+	}
+
+	public function test_get_simple_local_avatar_alt_with_default_avatar_with_alt() {
+		WP_Mock::userFunction( 'get_user_meta' )
+		       ->with( 1, 'simple_local_avatar', true )
+		       ->andReturn( [] );
+
+		WP_Mock::userFunction( 'get_option' )
+		       ->with( 'avatar_default' )
+		       ->andReturn( 'simple_local_avatar' );
+
+		WP_Mock::userFunction( 'get_option' )
+		       ->with( 'simple_local_avatar_default', '' )
+		       ->andReturn( 101 );
+
+		WP_Mock::userFunction( 'get_post_meta' )
+		       ->with( 101, '_wp_attachment_image_alt', true )
+		       ->andReturn( 'Custom alt text' );
+
+		$this->assertEquals( 'Custom alt text', $this->instance->get_simple_local_avatar_alt( 1 ) );
 	}
 
 	public function test_admin_init() {


### PR DESCRIPTION
### Description of the Change

In #127 we ensured that if an image that was set as an avatar had alt text associated with it, that alt text would be output. But if someone doesn't have a custom avatar set and instead we use a default avatar, that still doesn't output alt text.

This PR fixes that by:

1. Setting default alt text that will be used if no alt text can be found (defaulted to `Avatar photo` with a new filter around that so it can be changed)
2. If the default avatar being used was uploaded (instead of a default gravatar image) we try and pull the alt text from that image, if it exists. If not, we use the default mentioned above

Closes #146 

### How to test the Change

1. Ensure you're using a theme that outputs avatars
2. Set a default avatar to be one of the Gravatar options
3. Go to a post that was authored by someone without a custom avatar set
4. Inspect the source of the avatar and note the alt text should be showing `Avatar photo`
5. Change the default avatar to be an uploaded image that has alt text set
6. Inspect the source again and note the alt text should now be what was set on that image
7. If desired, test the `simple_local_avatars_default_alt` filter to ensure you can change the default alt text

### Changelog Entry

> Added - If a default avatar image is used, ensure that outputs alt text. This will either be default text (`Avatar photo`) or the alt text from the uploaded default image

### Credits

Props @dkotter

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
