### PR TITLE
Enhancement/148 | Expose hooks for "avatar updated" and "avatar deleted"

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -953,6 +953,14 @@ class Simple_Local_Avatars {
 		$meta_value['blog_id'] = get_current_blog_id();
 
 		update_user_meta( $user_id, $this->user_key, $meta_value ); // save user information (overwriting old).
+
+		/**
+		 * Enable themes and other plugins to react to changes to a user's avatar.
+		 *
+		 * @since 2.6.0
+		 *
+		 * @param int $user_id Id of the user who's avatar was updated
+		 */
 		do_action( 'simple_local_avatar_updated' , $user_id );
 	}
 
@@ -1055,6 +1063,14 @@ class Simple_Local_Avatars {
 			}
 
 			$this->avatar_delete( $user_id );    // delete old images if successful
+
+			/**
+			 * Enable themes and other plugins to react to avatar deletions.
+			 *
+			 * @since 2.6.0
+			 *
+			 * @param int $user_id Id of the user who's avatar was deleted.
+			 */
 			do_action( 'simple_local_avatar_deleted', $user_id );
 
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -953,7 +953,7 @@ class Simple_Local_Avatars {
 		$meta_value['blog_id'] = get_current_blog_id();
 
 		update_user_meta( $user_id, $this->user_key, $meta_value ); // save user information (overwriting old).
-		do_action("simple_local_avatar_updated", $user_id);
+		do_action( 'simple_local_avatar_updated' , $user_id );
 	}
 
 	/**

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -953,6 +953,7 @@ class Simple_Local_Avatars {
 		$meta_value['blog_id'] = get_current_blog_id();
 
 		update_user_meta( $user_id, $this->user_key, $meta_value ); // save user information (overwriting old).
+		do_action("simple_local_avatar_updated", $user_id);
 	}
 
 	/**
@@ -1054,6 +1055,7 @@ class Simple_Local_Avatars {
 			}
 
 			$this->avatar_delete( $user_id );    // delete old images if successful
+			do_action("simple_local_avatar_deleted", $user_id);
 
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 				echo wp_kses_post( get_simple_local_avatar( $user_id ) );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1055,7 +1055,7 @@ class Simple_Local_Avatars {
 			}
 
 			$this->avatar_delete( $user_id );    // delete old images if successful
-			do_action("simple_local_avatar_deleted", $user_id);
+			do_action( 'simple_local_avatar_deleted', $user_id );
 
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 				echo wp_kses_post( get_simple_local_avatar( $user_id ) );


### PR DESCRIPTION
### Description of the Change

Exposes two hooks, `simple_local_avatar_updated` and `simple_local_avatar_deleted`. These hooks allow theme developers or other plugin developers to react to changes in local avatars in a consistent and precise way. 

Example use cases include:
- sharing user avatars with external services such as chat or forum add-ons
- developing front-end flows for editing user profiles
- any use case adjacent to user management

Closes #148 

### Changelog Entry
> Added - Two hooks, `simple_local_avatar_updated` and `simple_local_avatar_deleted`


### Credits
@t-lock


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
