### PR TITLE
Fix: Non admin can not crop avatar

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -142,6 +142,13 @@ class Simple_Local_Avatars {
 				return $strings;
 			}, 10, 1 );
 		}
+
+		// Fix: An error occurred cropping the image (https://github.com/10up/simple-local-avatars/issues/141)
+		if ( isset( $_POST['action'] ) && 'crop-image' === $_POST['action'] && is_admin() && wp_doing_ajax() ) {
+			add_action( 'plugins_loaded', function() {
+				remove_all_actions( 'setup_theme' );
+			});
+		}
 	}
 
 	/**

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -143,11 +143,11 @@ class Simple_Local_Avatars {
 			}, 10, 1 );
 		}
 
-		// Fix: An error occurred cropping the image (https://github.com/10up/simple-local-avatars/issues/141)
+		// Fix: An error occurred cropping the image (https://github.com/10up/simple-local-avatars/issues/141).
 		if ( isset( $_POST['action'] ) && 'crop-image' === $_POST['action'] && is_admin() && wp_doing_ajax() ) {
-			add_action( 'plugins_loaded', function() {
+			add_action( 'plugins_loaded', function () {
 				remove_all_actions( 'setup_theme' );
-			});
+			} );
 		}
 	}
 


### PR DESCRIPTION
### Description of the Change

In this pull request we've just unregistered all the `setup_theme` action hook at application runtime during ajax call only when it is a crop request. As I debugged backtrace, I found this hook execution  ([https://github.com/WordPress/WordPress/blob/master/wp-settings.php#L549](https://github.com/WordPress/WordPress/blob/master/wp-settings.php#L549)) exits somewhere in case of non admin users. 

I definitely agree it's a very important hook, but as long as we are dealing with only image crop request, so I believe here's nothing to do with theme related stuffs. That's why cleared the hook for the crop request only. 

The issue description meant to integrate another crop tool other than the core one. But that would add more dev stacks. So 
 before proceeding new stacks, this pull request just proposes a simpler fix for the original issue #141 
If it doesn't seem an appropriate solution, then no issue to adopt a new crop tool. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #150 and #141 

### How to test the Change

1. Go to user edit screen as like as you do from admin account
2. Go to avatar section and click the button `Choose From Media Library` 
3. Select Avatar and Crop
4. Crop a portion as your wish
5. Click Crop button
6. Previously this is where you faced the error, but now it should save as expected. 

### Changelog Entry
> Fix: Non admin can not crop avatar