### PR TITLE
Address deprecation warning for wpmu_new_blog

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1239,7 +1239,7 @@ class Simple_Local_Avatars {
 	/**
 	 * Set plugin defaults for a new site
 	 *
-	 * @param int|WP_Site $blog_id Blog ID.
+	 * @param int|WP_Site $blog_id Blog ID or object.
 	 */
 	public function set_defaults( $blog_id ) {
 		if ( 'enforce' === $this->get_network_mode() ) {

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -100,6 +100,7 @@ class Simple_Local_Avatars {
 	 */
 	public function add_hooks() {
 		global $pagenow;
+		global $wp_version;
 
 		add_filter( 'plugin_action_links_' . SLA_PLUGIN_BASENAME, array( $this, 'plugin_filter_action_links' ) );
 
@@ -133,7 +134,12 @@ class Simple_Local_Avatars {
 		add_action( 'wp_ajax_sla_clear_user_cache', array( $this, 'sla_clear_user_cache' ) );
 
 		add_filter( 'avatar_defaults', array( $this, 'add_avatar_default_field' ) );
-		add_action( 'wpmu_new_blog', array( $this, 'set_defaults' ) );
+		if ( version_compare( $wp_version, '5.1', '<' ) {
+			add_action( 'wpmu_new_blog', array( $this, 'set_defaults' ) );
+		} else {
+			add_action( 'wp_initialize_site', array( $this, 'set_defaults' ) );
+		}
+		
 
 		if ( 'profile.php' === $pagenow ) {
 			add_filter( 'media_view_strings', function ( $strings ) {
@@ -1233,11 +1239,15 @@ class Simple_Local_Avatars {
 	/**
 	 * Set plugin defaults for a new site
 	 *
-	 * @param int $blog_id Blog ID.
+	 * @param int|WP_Site $blog_id Blog ID.
 	 */
 	public function set_defaults( $blog_id ) {
 		if ( 'enforce' === $this->get_network_mode() ) {
 			return;
+		}
+
+		if ( $blog_id instanceof WP_Site ) {
+			$blog_id = (int) $blog_id->blog_id;
 		}
 
 		switch_to_blog( $blog_id );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -134,7 +134,7 @@ class Simple_Local_Avatars {
 		add_action( 'wp_ajax_sla_clear_user_cache', array( $this, 'sla_clear_user_cache' ) );
 
 		add_filter( 'avatar_defaults', array( $this, 'add_avatar_default_field' ) );
-		if ( version_compare( $wp_version, '5.1', '<' ) {
+		if ( version_compare( $wp_version, '5.1', '<' ) ) {
 			add_action( 'wpmu_new_blog', array( $this, 'set_defaults' ) );
 		} else {
 			add_action( 'wp_initialize_site', array( $this, 'set_defaults' ) );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -139,7 +139,6 @@ class Simple_Local_Avatars {
 		} else {
 			add_action( 'wp_initialize_site', array( $this, 'set_defaults' ) );
 		}
-		
 
 		if ( 'profile.php' === $pagenow ) {
 			add_filter( 'media_view_strings', function ( $strings ) {


### PR DESCRIPTION
### Description of the Change

Adapt plugin to use `wp_initialize_site` instead of deprecated `wpmu_new_blog` hook when using a recent WordPress version.

`wpmu_new_blog` has been [deprecated since 5.1.0](https://developer.wordpress.org/reference/hooks/wpmu_new_blog/), in favor of [`wp_initialize_site`](https://developer.wordpress.org/reference/hooks/wp_initialize_site/) which receives a full WP_Site instance instead of the Blog ID.

This approach of checking the version matches how [`wordpress-seo` handles this](https://github.com/Yoast/wordpress-seo/blob/9946d8cdc97857fa8311be2ab0b11cce539beb98/wp-seo-main.php#L442-L449), but depending on this plugin's support matrix, the function could alternatively be switched over to use only the new hook.

### How to test the Change

I _have not_ exhaustively tested this locally. To test, create a new network site and verify whether the `simple_local_avatars` option has the expected defaults.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Set plugin defaults on `wp_initialize_site` instead of deprecated action `wpmu_new_blog`.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
