### PR TITLE
Respect the user profile language

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -68,13 +68,7 @@ class Simple_Local_Avatars {
 		$this->options        = (array) get_option( 'simple_local_avatars' );
 		$this->user_key       = 'simple_local_avatar';
 		$this->rating_key     = 'simple_local_avatar_rating';
-		$this->avatar_ratings = array(
-			'G'  => __( 'G &#8212; Suitable for all audiences' ),
-			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
-			'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
-			'X'  => __( 'X &#8212; Even more mature than above' ),
-		);
-
+		
 		if (
 			! $this->is_avatar_shared() // Are we sharing avatars?
 			&& (
@@ -512,6 +506,13 @@ class Simple_Local_Avatars {
 	 * Register admin settings.
 	 */
 	public function admin_init() {
+		$this->avatar_ratings = array(
+			'G'  => __( 'G &#8212; Suitable for all audiences', ),
+			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above', ),
+			'R'  => __( 'R &#8212; Intended for adult audiences above 17', ),
+			'X'  => __( 'X &#8212; Even more mature than above', ),
+		);
+
 		// upgrade pre 2.0 option
 		$old_ops = get_option( 'simple_local_avatars_caps' );
 		if ( $old_ops ) {

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -69,10 +69,10 @@ class Simple_Local_Avatars {
 		$this->user_key       = 'simple_local_avatar';
 		$this->rating_key     = 'simple_local_avatar_rating';
 		$this->avatar_ratings = array(
-			'G'  => __( 'G &#8212; Suitable for all audiences', 'simple-local-avatars' ),
-			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above', 'simple-local-avatars' ),
-			'R'  => __( 'R &#8212; Intended for adult audiences above 17', 'simple-local-avatars' ),
-			'X'  => __( 'X &#8212; Even more mature than above', 'simple-local-avatars' ),
+			'G'  => __( 'G &#8212; Suitable for all audiences' ),
+			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
+			'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
+			'X'  => __( 'X &#8212; Even more mature than above' ),
 		);
 
 		if (
@@ -917,8 +917,6 @@ class Simple_Local_Avatars {
 						<fieldset id="simple-local-avatar-ratings" <?php disabled( empty( $profileuser->simple_local_avatar ) ); ?>>
 							<legend class="screen-reader-text"><span><?php esc_html_e( 'Rating' ); ?></span></legend>
 							<?php
-							$this->update_avatar_ratings();
-
 							if ( empty( $profileuser->simple_local_avatar_rating ) || ! array_key_exists( $profileuser->simple_local_avatar_rating, $this->avatar_ratings ) ) {
 								$profileuser->simple_local_avatar_rating = 'G';
 							}
@@ -1300,20 +1298,6 @@ class Simple_Local_Avatars {
 		}
 
 		return $classes;
-	}
-
-	/**
-	 * Overwriting existing avatar_ratings so this can be called just before the rating strings would be used so that
-	 * translations will work correctly.
-	 * Default text-domain because the strings have already been translated
-	 */
-	private function update_avatar_ratings() {
-		$this->avatar_ratings = array(
-			'G'  => __( 'G &#8212; Suitable for all audiences' ),
-			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
-			'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
-			'X'  => __( 'X &#8212; Even more mature than above' ),
-		);
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
As per the findings added at https://github.com/10up/simple-local-avatars/issues/157#issuecomment-1320333432, this PR removes the textdomain from the core strings (as its not required there) which fixed issues #88 and #157.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #88, Closes #157

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Removed - Removed the textdomain from the core strings.
> Removed - The function `update_avatar_ratings` is removed as it's not required anymore.
> Fixed - Fixed the user profile language not respected issue.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @dkotter, @lllopo, @faisal-alvi , @jeffpaul 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
