### PR TITLE
Support WP_User objects

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -307,6 +307,8 @@ class Simple_Local_Avatars {
 			$user_id = (int) $id_or_email;
 		} elseif ( is_object( $id_or_email ) && ! empty( $id_or_email->user_id ) ) {
 			$user_id = (int) $id_or_email->user_id;
+		} elseif ( $id_or_email instanceof WP_User ) {
+			$user_id = $id_or_email->ID;
 		} elseif ( $id_or_email instanceof WP_Post && ! empty( $id_or_email->post_author ) ) {
 			$user_id = (int) $id_or_email->post_author;
 		} elseif ( is_string( $id_or_email ) ) {

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -489,4 +489,18 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 
 		$this->instance->avatar_delete( 1 );
 	}
+
+	public function test_get_user_id() {
+		$this->assertEquals( 0, $this->instance->get_user_id( '0' ) );
+		$this->assertEquals( 0, $this->instance->get_user_id( 'test@example.com' ) );
+
+		$user = new WP_User( [ 'ID' => 1 ] );
+		$this->assertEquals( 1, $this->instance->get_user_id( $user ) );
+
+		$post = new WP_Post( [ 'post_author' => '1' ] );
+		$this->assertEquals( 1, $this->instance->get_user_id( $post ) );
+
+		$comment = new WP_Comment( [ 'user_id' => '1' ] );
+		$this->assertEquals( 1, $this->instance->get_user_id( $comment ) );
+	}
 }

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -28,10 +28,9 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 			'X'  => __( 'X &#8212; Even more mature than above', 'simple-local-avatars' ),
 		) );
 
-		$user = (object) [
-			'ID'           => 1,
-			'display_name' => 'TEST_USER',
-		];
+		$user = Mockery::mock( WP_User::class );
+		$user->ID = 1;
+		$user->display_name = 'TEST_USER';
 
 		// Init $POST.
 		$_POST = array();
@@ -491,16 +490,19 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 	}
 
 	public function test_get_user_id() {
-		$this->assertEquals( 0, $this->instance->get_user_id( '0' ) );
-		$this->assertEquals( 0, $this->instance->get_user_id( 'test@example.com' ) );
+		$this->assertEquals( 1, $this->instance->get_user_id( '1' ) );
+		$this->assertEquals( 1, $this->instance->get_user_id( 'test@example.com' ) );
 
-		$user = new WP_User( [ 'ID' => 1 ] );
+		$user = Mockery::mock( WP_User::class );
+		$user->ID = 1;
 		$this->assertEquals( 1, $this->instance->get_user_id( $user ) );
 
-		$post = new WP_Post( [ 'post_author' => '1' ] );
+		$post = Mockery::mock( WP_Post::class );
+		$post->post_author = 1;
 		$this->assertEquals( 1, $this->instance->get_user_id( $post ) );
 
-		$comment = new WP_Comment( [ 'user_id' => '1' ] );
+		$comment = Mockery::mock( WP_Comment::class );
+		$comment->user_id = '1';
 		$this->assertEquals( 1, $this->instance->get_user_id( $comment ) );
 	}
 }

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -28,8 +28,8 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 			'X'  => __( 'X &#8212; Even more mature than above', 'simple-local-avatars' ),
 		) );
 
-		$user = Mockery::mock( WP_User::class );
-		$user->ID = 1;
+		$user               = Mockery::mock( WP_User::class );
+		$user->ID           = 1;
 		$user->display_name = 'TEST_USER';
 
 		// Init $POST.
@@ -493,15 +493,15 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		$this->assertEquals( 1, $this->instance->get_user_id( '1' ) );
 		$this->assertEquals( 1, $this->instance->get_user_id( 'test@example.com' ) );
 
-		$user = Mockery::mock( WP_User::class );
+		$user     = Mockery::mock( WP_User::class );
 		$user->ID = 1;
 		$this->assertEquals( 1, $this->instance->get_user_id( $user ) );
 
-		$post = Mockery::mock( WP_Post::class );
+		$post              = Mockery::mock( WP_Post::class );
 		$post->post_author = 1;
 		$this->assertEquals( 1, $this->instance->get_user_id( $post ) );
 
-		$comment = Mockery::mock( WP_Comment::class );
+		$comment          = Mockery::mock( WP_Comment::class );
 		$comment->user_id = '1';
 		$this->assertEquals( 1, $this->instance->get_user_id( $comment ) );
 	}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
It is expected that I can pass `WP_User` object to [`get_avatar`, as is documented](https://developer.wordpress.org/reference/functions/get_avatar/). But this does not work because `get_user_id` in `Simple_Local_Avatars` does not handle this case. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #192

### How to test the Change
```
$user = wp_get_current_user();
echo get_avatar( $user );
```

### Changelog Entry

> Fixed - Support passing `WP_User` to `get_avatar`.

### Credits
Props @mattheu

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [ ] All new and existing tests pass.
