### PR TITLE
Removed trailing commas

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -524,13 +524,13 @@ class Simple_Local_Avatars {
 		 */
 		$this->avatar_ratings = array(
 			/* translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system */
-			'G'  => __( 'G &#8212; Suitable for all audiences', ),
+			'G'  => __( 'G &#8212; Suitable for all audiences' ),
 			/* translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system */
-			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above', ),
+			'PG' => __( 'PG &#8212; Possibly offensive, usually for audiences 13 and above' ),
 			/* translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system */
-			'R'  => __( 'R &#8212; Intended for adult audiences above 17', ),
+			'R'  => __( 'R &#8212; Intended for adult audiences above 17' ),
 			/* translators: Content suitability rating: https://en.wikipedia.org/wiki/Motion_Picture_Association_of_America_film_rating_system */
-			'X'  => __( 'X &#8212; Even more mature than above', ),
+			'X'  => __( 'X &#8212; Even more mature than above' ),
 		);
 	}
 


### PR DESCRIPTION
Hey @dkotter, just removed the trailing commas from the code. This should fix the issue with latest PHP versions 7+

### Description of the Change

Removed the trailing commas from `gettext` call on line 527, 529, 531 and 533

Closes #195

### How to test the Change

### Changelog Entry

> Fixed - Remove trailing commas in function calls.


### Credits

Props @sekra24


### Checklist:

- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
