### PR TITLE
Avatar removal button text update

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -926,7 +926,7 @@ class Simple_Local_Avatars {
 									<a href="#" class="button hide-if-no-js" id="simple-local-avatar-media"><?php esc_html_e( 'Choose from Media Library', 'simple-local-avatars' ); ?></a> &nbsp;
 								<?php endif; ?>
 								<a href="<?php echo esc_url( $remove_url ); ?>" class="button item-delete submitdelete deletion" id="simple-local-avatar-remove" <?php echo empty( $profileuser->simple_local_avatar ) ? ' style="display:none;"' : ''; ?>>
-									<?php esc_html_e( 'Delete local avatar', 'simple-local-avatars' ); ?>
+									<?php esc_html_e( 'Remove local avatar', 'simple-local-avatars' ); ?>
 								</a>
 							</p>
 							<?php


### PR DESCRIPTION
### Description of the Change
Avatar removal text changed to `Remove local avatar` from `Delete local avatar`. This PR is created based on this [comment](https://github.com/10up/simple-local-avatars/pull/180#issuecomment-1480322037)  on PR #180 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #41

### How to test the Change

- Go to profile edit page
- Set local avatar and save
- Now you should see removal button text is `Remove local avatar`

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Avatar removal button text


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jayedul, @dkotter, @faisal-alvi 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
