### PR TITLE
Host/Domain change support added for local avatar url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ tests/cypress/screenshots
 tests/cypress/videos
 tests/cypress/downloads
 tests/cypress/reports
+
+.phpunit.result.cache

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -335,6 +335,8 @@ class Simple_Local_Avatars {
 			return '';
 		}
 
+
+
 		// Fetch local avatar from meta and make sure it's properly set.
 		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
 		if ( empty( $local_avatars['media_id'] ) ) {
@@ -357,7 +359,7 @@ class Simple_Local_Avatars {
 		if ( ! empty( $local_avatars['media_id'] ) ) {
 			// If using shared avatars, make sure we validate the URL on the main site.
 			if ( $this->is_avatar_shared() ) {
-				$origin_blog_id = isset( $local_avatars['blog_id'] ) && ! empty( $local_avatars['blog_id'] ) ? $local_avatars['blog_id'] : get_main_site_id();
+				$origin_blog_id = ! empty( $local_avatars['blog_id'] ) ? $local_avatars['blog_id'] : get_main_site_id();
 				switch_to_blog( $origin_blog_id );
 			}
 
@@ -419,7 +421,7 @@ class Simple_Local_Avatars {
 			endif;
 		}
 
-		if ( 'http' !== substr( $local_avatars[ $size ], 0, 4 ) ) {
+		if ( strpos( $local_avatars[ $size ], 'http' ) !== 0 ) {
 			$local_avatars[ $size ] = home_url( $local_avatars[ $size ] );
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -335,8 +335,6 @@ class Simple_Local_Avatars {
 			return '';
 		}
 
-
-
 		// Fetch local avatar from meta and make sure it's properly set.
 		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
 		if ( empty( $local_avatars['media_id'] ) ) {

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -339,7 +339,7 @@ class Simple_Local_Avatars {
 		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
 
 		// Return avatar if exists.
-		if ( array_key_exists( $size, $local_avatars ) && ( strpos( $local_avatars[ $size ], content_url() ) === 0 ) ) {
+		if ( is_array( $local_avatars ) && array_key_exists( $size, $local_avatars ) && ( strpos( $local_avatars[ $size ], content_url() ) === 0 ) ) {
 			return esc_url( $local_avatars[ $size ] );
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -337,7 +337,7 @@ class Simple_Local_Avatars {
 
 		// Fetch local avatar from meta and make sure it's properly set.
 		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
-		if ( empty( $local_avatars['full'] ) ) {
+		if ( empty( $local_avatars['media_id'] ) ) {
 			return '';
 		}
 
@@ -371,12 +371,15 @@ class Simple_Local_Avatars {
 			if ( ! $avatar_full_path ) {
 				return '';
 			}
+
+			// Use dynamic full url in favour of host/domain change.
+			$local_avatars['full'] = wp_get_attachment_image_url( $local_avatars['media_id'], 'full' );
 		}
 
 		$size = (int) $size;
 
 		// Generate a new size.
-		if ( ! array_key_exists( $size, $local_avatars ) ) {
+		if ( ! array_key_exists( $size, $local_avatars ) || ! ( strpos( $local_avatars[ $size ], content_url() ) === 0 ) ) {
 			$local_avatars[ $size ] = $local_avatars['full']; // just in case of failure elsewhere
 
 			// allow automatic rescaling to be turned off

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -335,8 +335,14 @@ class Simple_Local_Avatars {
 			return '';
 		}
 
-		// Fetch local avatar from meta and make sure it's properly set.
 		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
+
+		// Return avatar if exists.
+		if ( array_key_exists( $size, $local_avatars ) && ( strpos( $local_avatars[ $size ], content_url() ) === 0 ) ) {
+			return esc_url( $local_avatars[ $size ] );
+		}
+
+		// Fetch local avatar from meta and make sure it's properly set.
 		if ( empty( $local_avatars['media_id'] ) ) {
 			return '';
 		}

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -65,9 +65,9 @@ class Simple_Local_Avatars {
 	public function __construct() {
 		$this->add_hooks();
 
-		$this->options        = (array) get_option( 'simple_local_avatars' );
-		$this->user_key       = 'simple_local_avatar';
-		$this->rating_key     = 'simple_local_avatar_rating';
+		$this->options    = (array) get_option( 'simple_local_avatars' );
+		$this->user_key   = 'simple_local_avatar';
+		$this->rating_key = 'simple_local_avatar_rating';
 
 		if (
 			! $this->is_avatar_shared() // Are we sharing avatars?
@@ -136,18 +136,26 @@ class Simple_Local_Avatars {
 		}
 
 		if ( 'profile.php' === $pagenow ) {
-			add_filter( 'media_view_strings', function ( $strings ) {
-				$strings['skipCropping'] = esc_html__( 'Default Crop', 'simple-local-avatars' );
+			add_filter(
+				'media_view_strings',
+				function ( $strings ) {
+					$strings['skipCropping'] = esc_html__( 'Default Crop', 'simple-local-avatars' );
 
-				return $strings;
-			}, 10, 1 );
+					return $strings;
+				},
+				10,
+				1
+			);
 		}
 
 		// Fix: An error occurred cropping the image (https://github.com/10up/simple-local-avatars/issues/141).
 		if ( isset( $_POST['action'] ) && 'crop-image' === $_POST['action'] && is_admin() && wp_doing_ajax() ) {
-			add_action( 'plugins_loaded', function () {
-				remove_all_actions( 'setup_theme' );
-			} );
+			add_action(
+				'plugins_loaded',
+				function () {
+					remove_all_actions( 'setup_theme' );
+				}
+			);
 		}
 	}
 
@@ -330,7 +338,7 @@ class Simple_Local_Avatars {
 	 */
 	public function get_simple_local_avatar_url( $id_or_email, $size ) {
 		$user_id = $this->get_user_id( $id_or_email );
-		$size = (int) $size;
+		$size    = (int) $size;
 
 		if ( empty( $user_id ) ) {
 			return '';
@@ -407,7 +415,7 @@ class Simple_Local_Avatars {
 						$dest_file_url = '';
 						if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
 							$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
-						} else if ( is_multisite() && false !== strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
+						} elseif ( is_multisite() && false !== strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
 							$dest_file_url = str_replace( ABSPATH . 'wp-content/uploads', network_site_url( '/wp-content/uploads' ), $dest_file );
 						}
 
@@ -1008,7 +1016,7 @@ class Simple_Local_Avatars {
 		 *
 		 * @param int $user_id Id of the user who's avatar was updated
 		 */
-		do_action( 'simple_local_avatar_updated' , $user_id );
+		do_action( 'simple_local_avatar_updated', $user_id );
 	}
 
 	/**
@@ -1415,9 +1423,9 @@ class Simple_Local_Avatars {
 				$file_name_data = pathinfo( get_attached_file( $media_id ) );
 			}
 
-			$file_dir_name  = $file_name_data['dirname'];
-			$file_name      = $file_name_data['filename'];
-			$file_ext       = $file_name_data['extension'];
+			$file_dir_name = $file_name_data['dirname'];
+			$file_name     = $file_name_data['filename'];
+			$file_ext      = $file_name_data['extension'];
 			foreach ( $local_avatars as $local_avatars_key => $local_avatar_value ) {
 				if ( ! in_array( $local_avatars_key, [ 'media_id', 'full' ], true ) ) {
 					$file_size_path = sprintf( '%1$s/%2$s-%3$sx%3$s.%4$s', $file_dir_name, $file_name, $local_avatars_key, $file_ext );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -360,27 +360,25 @@ class Simple_Local_Avatars {
 		}
 
 		// handle "real" media
-		if ( ! empty( $local_avatars['media_id'] ) ) {
-			// If using shared avatars, make sure we validate the URL on the main site.
-			if ( $this->is_avatar_shared() ) {
-				$origin_blog_id = ! empty( $local_avatars['blog_id'] ) ? $local_avatars['blog_id'] : get_main_site_id();
-				switch_to_blog( $origin_blog_id );
-			}
-
-			$avatar_full_path = get_attached_file( $local_avatars['media_id'] );
-
-			if ( $this->is_avatar_shared() ) {
-				restore_current_blog();
-			}
-
-			// has the media been deleted?
-			if ( ! $avatar_full_path ) {
-				return '';
-			}
-
-			// Use dynamic full url in favour of host/domain change.
-			$local_avatars['full'] = wp_get_attachment_image_url( $local_avatars['media_id'], 'full' );
+		// If using shared avatars, make sure we validate the URL on the main site.
+		if ( $this->is_avatar_shared() ) {
+			$origin_blog_id = ! empty( $local_avatars['blog_id'] ) ? $local_avatars['blog_id'] : get_main_site_id();
+			switch_to_blog( $origin_blog_id );
 		}
+
+		$avatar_full_path = get_attached_file( $local_avatars['media_id'] );
+
+		if ( $this->is_avatar_shared() ) {
+			restore_current_blog();
+		}
+
+		// has the media been deleted?
+		if ( ! $avatar_full_path ) {
+			return '';
+		}
+
+		// Use dynamic full url in favour of host/domain change.
+		$local_avatars['full'] = wp_get_attachment_image_url( $local_avatars['media_id'], 'full' );
 
 		$size = (int) $size;
 

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -64,6 +64,13 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		       ->with( 101 )
 		       ->andReturn( '/avatar.png' );
 
+		WP_Mock::userFunction( 'wp_get_attachment_image_url' )
+		       ->with( 101, 'full' )
+		       ->andReturn( '/avatar.png' );
+
+		WP_Mock::userFunction( 'content_url' )
+		       ->andReturn( 'http://localhost/simple-local-avatar/wp-content' );
+
 		WP_Mock::userFunction( 'admin_url' )
 		       ->with( 'options-discussion.php' )
 		       ->andReturn( 'wp-admin/options-discussion.php' );
@@ -196,9 +203,18 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		WP_Mock::userFunction( 'get_user_meta' )
 		       ->with( 2, 'simple_local_avatar', true )
 		       ->andReturn( [ 'media_id' => 102 ] );
+
 		WP_Mock::userFunction( 'get_attached_file' )
 		       ->with( 102 )
 		       ->andReturn( false );
+			   
+		WP_Mock::userFunction( 'wp_get_attachment_image_url' )
+		       ->with( 102, 'full' )
+		       ->andReturn( false );
+
+		WP_Mock::userFunction( 'content_url' )
+		       ->andReturn( 'http://localhost/simple-local-avatar/wp-content' );
+
 		$this->assertEquals( '', $this->instance->get_simple_local_avatar_url( 2, 96 ) );
 	}
 

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -69,7 +69,7 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		       ->andReturn( '/avatar.png' );
 
 		WP_Mock::userFunction( 'content_url' )
-		       ->andReturn( 'http://localhost/simple-local-avatar/wp-content' );
+		       ->andReturn( 'https://example.com/' );
 
 		WP_Mock::userFunction( 'admin_url' )
 		       ->with( 'options-discussion.php' )
@@ -207,13 +207,13 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		WP_Mock::userFunction( 'get_attached_file' )
 		       ->with( 102 )
 		       ->andReturn( false );
-			   
+
 		WP_Mock::userFunction( 'wp_get_attachment_image_url' )
 		       ->with( 102, 'full' )
 		       ->andReturn( false );
 
 		WP_Mock::userFunction( 'content_url' )
-		       ->andReturn( 'http://localhost/simple-local-avatar/wp-content' );
+		       ->andReturn( 'http://example.com' );
 
 		$this->assertEquals( '', $this->instance->get_simple_local_avatar_url( 2, 96 ) );
 	}

--- a/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
+++ b/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
@@ -138,7 +138,7 @@ class SimpleLocalAvatarsNetworkTest extends \WP_Mock\Tools\TestCase {
 		] );
 		WP_Mock::userFunction( 'content_url', [
 			'args'   => [],
-			'return' => 'http://localhost/simple-local-avatar/wp-content',
+			'return' => 'http://example.com',
 			'times'  => 1,
 		] );
 		WP_Mock::userFunction( 'get_option' )

--- a/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
+++ b/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
@@ -141,6 +141,30 @@ class SimpleLocalAvatarsNetworkTest extends \WP_Mock\Tools\TestCase {
 			'return' => 'http://example.com',
 			'times'  => 1,
 		] );
+		WP_Mock::userFunction( 'wp_upload_dir', [
+			'args'   => [],
+			'return' => ['baseurl' => '', 'basedir' => ''],
+			'times'  => 1,
+		] );
+		WP_Mock::userFunction( 'wp_get_image_editor', [
+			'args'   => [ '/avatar.png' ],
+			'return' => false,
+			'times'  => 1,
+		] );
+		WP_Mock::userFunction( 'is_wp_error', [
+			'return' => true,
+			'times'  => 1,
+			] );
+		WP_Mock::userFunction( 'update_user_meta', [
+			'args'   => [ 1, 'simple_local_avatar', ['media_id' => 101, 'full' => '/avatar.png', 96 => '/avatar.png'] ],
+			'return' => true,
+			'times'  => 1,
+		] );
+		WP_Mock::userFunction( 'home_url', [
+			'args'   => [ '/avatar.png' ],
+			'return' => 'https://example.com/avatar-96x96.png',
+			'times'  => 1,
+		] );
 		WP_Mock::userFunction( 'get_option' )
 		       ->with( 'avatar_rating' )
 		       ->andReturn( false );

--- a/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
+++ b/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
@@ -131,6 +131,16 @@ class SimpleLocalAvatarsNetworkTest extends \WP_Mock\Tools\TestCase {
 			'return' => '/avatar.png',
 			'times'  => 1,
 		] );
+		WP_Mock::userFunction( 'wp_get_attachment_image_url', [
+			'args'   => [ 101, 'full' ],
+			'return' => '/avatar.png',
+			'times'  => 1,
+		] );
+		WP_Mock::userFunction( 'content_url', [
+			'args'   => [],
+			'return' => 'http://localhost/simple-local-avatar/wp-content',
+			'times'  => 1,
+		] );
 		WP_Mock::userFunction( 'get_option' )
 		       ->with( 'avatar_rating' )
 		       ->andReturn( false );


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Current domain/host will be used for local avatar URLs even after site migration.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #64 

### How to test the Change

- Simply edit the image url host in `simple_local_avatar` user meta, maybe in database directly for easy test.
- Reload the page wherever the avatar image is supposed to load
- The image should be regenerated for that specific avatar size and the URL should get back to its original state based on current host/domain. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Local avatar urls remain old after domain/host change


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jayedul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
