### PR TITLE
Remove the wp enqueue media in avatar default filter

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1436,9 +1436,6 @@ class Simple_Local_Avatars {
 	 * @return array Default options of avatar.
 	 */
 	public function add_avatar_default_field( $defaults ) {
-		if ( ! did_action( 'wp_enqueue_media' ) ) {
-			wp_enqueue_media();
-		}
 		$default_avatar_file_url = '';
 		$default_avatar_file_id  = get_option( 'simple_local_avatar_default', '' );
 		if ( ! empty( $default_avatar_file_id ) ) {


### PR DESCRIPTION
### Description of the Change
Fixes conflict with plugins in which wp.media is not loaded or correctly working. Elementor page editor specifically fails to function due to this.

I see that this has been here for a long time, so I'm unsure what might have changed since then, but the Elementor image editor fails to work, doing wp_enqueue_media here appears to be the cause. Although I see that wp_enqueue_media also checks if it has run, so it isn't about enqueuing things twice. 

Within the discussions options page the media library works still, I believe the media api is enqueue elsewhere so it will be available here, without having to do it here while the default avatar options are updated. 


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #217 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Attempting to edit any image prior to this change in Elementor page editor would do nothing. 
As well as tell tale console errors about wp.media and the javascript API

After this change testing and media library opens for Elementor image elements. 
Further testing the discussions option page, and the default avatar option for local simple avatars is present and working, media library opens up, and assigning an image loads it into the form. 

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Address conflicts with other plugins and loading the media API 



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.

I couldn't get the cypress unit tests to run, but it shouldn't require any new tests or affect the tests I see that exist
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
