### PR TITLE
Allow shared avatars only for multisite

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -202,13 +202,13 @@ class Simple_Local_Avatars {
 	 * @return boolean
 	 */
 	public function is_avatar_shared() {
+		if ( ! is_multisite() ) {
+			return false;
+		}
+
 		if (
-			is_multisite() // Are we on multisite.
-			&& ! isset( $this->options['shared'] ) // And our shared option doesn't exist.
-			|| (
-				isset( $this->options['shared'] ) // Or our shared option is set.
-				&& 1 === $this->options['shared']
-			)
+			! isset( $this->options['shared'] ) // Our shared option doesn't exist.
+			|| 1 === $this->options['shared']  // Or our shared option is set.
 		) {
 			return true;
 		}


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixes #221.

Changes `is_avatar_shared()` to always return `false` if not used in a multisite. Brings it in line with https://github.com/10up/simple-local-avatars/blob/801cc93a36ac38b495ac756cb27d78ccc6234a0a/includes/class-simple-local-avatars.php#L580-L594

### How to test the Change
See #221

### Changelog Entry
Fixed - Prevent PHP fatal error when switching from a multisite to single site installation.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ocean90


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
