### PR TITLE
Upgrade npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "2.7.5",
       "license": "GNU General Public License v2.0",
       "devDependencies": {
-        "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
-        "@wordpress/env": "^5.2.0",
+        "@10up/cypress-wp-utils": "^0.2.0",
+        "@wordpress/env": "^8.7.0",
         "@wordpress/scripts": "^23.0.0",
-        "cypress": "^13.1.0",
+        "cypress": "^13.2.0",
         "cypress-file-upload": "^5.0.8",
-        "cypress-mochawesome-reporter": "^3.0.1"
+        "cypress-mochawesome-reporter": "^3.6.0"
       }
     },
     "node_modules/@10up/cypress-wp-utils": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/10up/cypress-wp-utils.git#ec20aed9c16f460f3e7d0c06c447f4fb8d030404",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+      "integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0"
       }
@@ -3273,9 +3273,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -3551,9 +3551,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3714,9 +3714,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3773,9 +3773,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4121,9 +4121,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.9.0.tgz",
-      "integrity": "sha512-z1RnzLzirhmxQHqhmfAMBC2YTXF2W7fkrblQTu+5j/zC1Cl0u/sPb0FBRv/NLRoDclt9be4Jgm5DfaJYZQEPlA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
+      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -6475,9 +6475,9 @@
       }
     },
     "node_modules/css-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6689,15 +6689,15 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
-      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -6759,21 +6759,37 @@
       }
     },
     "node_modules/cypress-mochawesome-reporter": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.2.3.tgz",
-      "integrity": "sha512-gUtIYBH+KvnAeCkTFu/t9niX1KHnAbEZyxBFvEHQRtrQNXLERjLJjGOHIW6kuESIdVMiEFOcvuNF2LuBpORW9A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.6.0.tgz",
+      "integrity": "sha512-NeYpeZVB5YCU10I3a1yA2qHt+YREo0jZw4Gj83JTJ7YX/ZLFfd8MYKl2O19d/yYC8np/fpMufp5gt3ympd9DWQ==",
       "dev": true,
       "dependencies": {
+        "commander": "^10.0.1",
         "fs-extra": "^10.0.1",
         "mochawesome": "^7.1.3",
         "mochawesome-merge": "^4.2.1",
         "mochawesome-report-generator": "^6.2.0"
       },
+      "bin": {
+        "generate-mochawesome-report": "cli.js"
+      },
       "engines": {
         "node": ">=14"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/LironEr"
+      },
       "peerDependencies": {
         "cypress": ">=6.2.0"
+      }
+    },
+    "node_modules/cypress-mochawesome-reporter/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/cypress-mochawesome-reporter/node_modules/fs-extra": {
@@ -6789,12 +6805,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/cypress/node_modules/@types/node": {
-      "version": "16.18.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
-      "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
-      "dev": true
     },
     "node_modules/cypress/node_modules/commander": {
       "version": "6.2.1",
@@ -8153,9 +8163,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11632,9 +11642,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -13523,9 +13533,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -13619,9 +13629,9 @@
       }
     },
     "node_modules/npm-package-json-lint/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -14580,9 +14590,9 @@
       }
     },
     "node_modules/postcss-loader/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -16217,9 +16227,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -17199,9 +17209,9 @@
       }
     },
     "node_modules/stylelint/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -19117,9 +19127,10 @@
   },
   "dependencies": {
     "@10up/cypress-wp-utils": {
-      "version": "git+ssh://git@github.com/10up/cypress-wp-utils.git#ec20aed9c16f460f3e7d0c06c447f4fb8d030404",
-      "dev": true,
-      "from": "@10up/cypress-wp-utils@github:10up/cypress-wp-utils#build"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@10up/cypress-wp-utils/-/cypress-wp-utils-0.2.0.tgz",
+      "integrity": "sha512-5gzamtHIFojT+wx0OzSAEeVY6FVrlcVPHVFH23uExkaqQhNsJvrnpdtqtT98wAYkXg56c1qDN7Ju7ZRTaNzP5g==",
+      "dev": true
     },
     "@ampproject/remapping": {
       "version": "2.2.0",
@@ -21475,9 +21486,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "version": "18.17.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.15.tgz",
+      "integrity": "sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -21732,9 +21743,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -21822,9 +21833,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -21864,9 +21875,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -22159,9 +22170,9 @@
       }
     },
     "@wordpress/env": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-5.9.0.tgz",
-      "integrity": "sha512-z1RnzLzirhmxQHqhmfAMBC2YTXF2W7fkrblQTu+5j/zC1Cl0u/sPb0FBRv/NLRoDclt9be4Jgm5DfaJYZQEPlA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.7.0.tgz",
+      "integrity": "sha512-cqjDjFFLZ8691mzsuPaakoNbUJ5d6DNNRMyN6UZefLGKhthlqmyK5DqzXZUzCr9cgF/kdc//v3ZmBy9nywBYSA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -23899,9 +23910,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -24062,14 +24073,14 @@
       }
     },
     "cypress": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
-      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -24112,12 +24123,6 @@
         "yauzl": "^2.10.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "16.18.48",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
-          "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
-          "dev": true
-        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -24179,17 +24184,24 @@
       "requires": {}
     },
     "cypress-mochawesome-reporter": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.2.3.tgz",
-      "integrity": "sha512-gUtIYBH+KvnAeCkTFu/t9niX1KHnAbEZyxBFvEHQRtrQNXLERjLJjGOHIW6kuESIdVMiEFOcvuNF2LuBpORW9A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/cypress-mochawesome-reporter/-/cypress-mochawesome-reporter-3.6.0.tgz",
+      "integrity": "sha512-NeYpeZVB5YCU10I3a1yA2qHt+YREo0jZw4Gj83JTJ7YX/ZLFfd8MYKl2O19d/yYC8np/fpMufp5gt3ympd9DWQ==",
       "dev": true,
       "requires": {
+        "commander": "^10.0.1",
         "fs-extra": "^10.0.1",
         "mochawesome": "^7.1.3",
         "mochawesome-merge": "^4.2.1",
         "mochawesome-report-generator": "^6.2.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+          "dev": true
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -25272,9 +25284,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -27779,9 +27791,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -29288,9 +29300,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -29361,9 +29373,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -30063,9 +30075,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -31205,9 +31217,9 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
     "send": {
@@ -31987,9 +31999,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
   "author": "10up",
   "license": "GNU General Public License v2.0",
   "devDependencies": {
-    "@10up/cypress-wp-utils": "github:10up/cypress-wp-utils#build",
-    "@wordpress/env": "^5.2.0",
+    "@10up/cypress-wp-utils": "^0.2.0",
+    "@wordpress/env": "^8.7.0",
     "@wordpress/scripts": "^23.0.0",
-    "cypress": "^13.1.0",
+    "cypress": "^13.2.0",
     "cypress-file-upload": "^5.0.8",
-    "cypress-mochawesome-reporter": "^3.0.1"
+    "cypress-mochawesome-reporter": "^3.6.0"
   }
 }

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
-npm run env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+wp-env run tests-wordpress chmod -c ugo+w /var/www/html
+wp-env run tests-cli wp rewrite structure '/%postname%/' --hard

--- a/tests/cypress/integration/admin.test.js
+++ b/tests/cypress/integration/admin.test.js
@@ -1,5 +1,5 @@
 describe('Admin can login and make sure plugin is activated', () => {
-    before(() => {
+    beforeEach(() => {
         cy.login();
     });
 

--- a/tests/cypress/integration/avatars-migration.test.js
+++ b/tests/cypress/integration/avatars-migration.test.js
@@ -1,5 +1,5 @@
 describe('Avatar migration', () => {
-    before(() => {
+    beforeEach(() => {
         cy.login();
     });
 

--- a/tests/cypress/integration/choose-default-avatar.test.js
+++ b/tests/cypress/integration/choose-default-avatar.test.js
@@ -1,5 +1,5 @@
 describe('Check if a default avatar can be set', () => {
-    before(() => {
+    beforeEach(() => {
         cy.login();
     });
 

--- a/tests/cypress/integration/clear-avatars-cache.test.js
+++ b/tests/cypress/integration/clear-avatars-cache.test.js
@@ -1,5 +1,5 @@
 describe('Check if avatar cache can be cleared', () => {
-    before(() => {
+    beforeEach(() => {
         cy.login();
     });
 

--- a/tests/cypress/integration/delete-avatar.test.js
+++ b/tests/cypress/integration/delete-avatar.test.js
@@ -1,7 +1,7 @@
 import 'cypress-file-upload';
 
 describe('Check if admin can delete avatar', () => {
-    before(() => {
+    beforeEach(() => {
         cy.login();
     });
 

--- a/tests/cypress/integration/set-avatar.test.js
+++ b/tests/cypress/integration/set-avatar.test.js
@@ -1,7 +1,7 @@
 import 'cypress-file-upload';
 
 describe('Check if admin can upload, crop and select local avatar', () => {
-    before(() => {
+    beforeEach(() => {
         cy.login();
     });
 

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -12,14 +12,16 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-const { readConfig } = require("@wordpress/env/lib/config");
+const { loadConfig } = require("@wordpress/env/lib/config");
+const getCacheDirectory = require("@wordpress/env/lib/config/get-cache-directory");
 
 /**
  * @type {Cypress.PluginConfig}
  */
 // eslint-disable-next-line no-unused-vars
 module.exports = async (on, config) => {
-  wpEnvConfig = await readConfig("wp-env");
+  const cacheDirectory = await getCacheDirectory();
+  const wpEnvConfig = await loadConfig(cacheDirectory);
 
   if (wpEnvConfig) {
     const port = wpEnvConfig.env.tests.port || null;

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -17,11 +17,3 @@ import "@10up/cypress-wp-utils";
 
 // Import commands.js using ES2015 syntax:
 import "./commands";
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-beforeEach(() => {
-  Cypress.Cookies.defaults({
-    preserve: /^wordpress.*?/,
-  });
-});


### PR DESCRIPTION
### Description of the Change

This PR upgrades the Cypress, Cypress utils lib, and @wordpress/env. Updates needed files as part of the upgrade.

- Bump Cypress version from 13.1.0 to 13.2.0
- Bump @10up/cypress-wp-utils version to 0.2.0
- Bump @wordpress/env version from 5.2.0 to 8.7.0
- Bump cypress-mochawesome-reporter from 3.0.1 to 3.6.0

Closes #227

### How to test the Change
Make sure PR `PASS` E2E tests check OR verify E2E tests locally.

### Changelog Entry
> Changed - Bump `Cypress` version from 13.1.0 to 13.2.0
> Changed - Bump `@10up/cypress-wp-utils` version to 0.2.0
> Changed - Bump `@wordpress/env` version from 5.2.0 to 8.7.0
> Changed - Bump `cypress-mochawesome-reporter` version from 3.0.1 to 3.6.0


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
