### PR TITLE
Revert "Host/Domain change support added for local avatar url"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,3 @@ tests/cypress/screenshots
 tests/cypress/videos
 tests/cypress/downloads
 tests/cypress/reports
-
-.phpunit.result.cache

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -64,13 +64,6 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		       ->with( 101 )
 		       ->andReturn( '/avatar.png' );
 
-		WP_Mock::userFunction( 'wp_get_attachment_image_url' )
-		       ->with( 101, 'full' )
-		       ->andReturn( '/avatar.png' );
-
-		WP_Mock::userFunction( 'content_url' )
-		       ->andReturn( 'https://example.com/' );
-
 		WP_Mock::userFunction( 'admin_url' )
 		       ->with( 'options-discussion.php' )
 		       ->andReturn( 'wp-admin/options-discussion.php' );
@@ -203,18 +196,9 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		WP_Mock::userFunction( 'get_user_meta' )
 		       ->with( 2, 'simple_local_avatar', true )
 		       ->andReturn( [ 'media_id' => 102 ] );
-
 		WP_Mock::userFunction( 'get_attached_file' )
 		       ->with( 102 )
 		       ->andReturn( false );
-
-		WP_Mock::userFunction( 'wp_get_attachment_image_url' )
-		       ->with( 102, 'full' )
-		       ->andReturn( false );
-
-		WP_Mock::userFunction( 'content_url' )
-		       ->andReturn( 'http://example.com' );
-
 		$this->assertEquals( '', $this->instance->get_simple_local_avatar_url( 2, 96 ) );
 	}
 

--- a/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
+++ b/tests/phpunit/multisite/SimpleLocalAvatarsNetworkTest.php
@@ -131,40 +131,6 @@ class SimpleLocalAvatarsNetworkTest extends \WP_Mock\Tools\TestCase {
 			'return' => '/avatar.png',
 			'times'  => 1,
 		] );
-		WP_Mock::userFunction( 'wp_get_attachment_image_url', [
-			'args'   => [ 101, 'full' ],
-			'return' => '/avatar.png',
-			'times'  => 1,
-		] );
-		WP_Mock::userFunction( 'content_url', [
-			'args'   => [],
-			'return' => 'http://example.com',
-			'times'  => 1,
-		] );
-		WP_Mock::userFunction( 'wp_upload_dir', [
-			'args'   => [],
-			'return' => ['baseurl' => '', 'basedir' => ''],
-			'times'  => 1,
-		] );
-		WP_Mock::userFunction( 'wp_get_image_editor', [
-			'args'   => [ '/avatar.png' ],
-			'return' => false,
-			'times'  => 1,
-		] );
-		WP_Mock::userFunction( 'is_wp_error', [
-			'return' => true,
-			'times'  => 1,
-			] );
-		WP_Mock::userFunction( 'update_user_meta', [
-			'args'   => [ 1, 'simple_local_avatar', ['media_id' => 101, 'full' => '/avatar.png', 96 => '/avatar.png'] ],
-			'return' => true,
-			'times'  => 1,
-		] );
-		WP_Mock::userFunction( 'home_url', [
-			'args'   => [ '/avatar.png' ],
-			'return' => 'https://example.com/avatar-96x96.png',
-			'times'  => 1,
-		] );
 		WP_Mock::userFunction( 'get_option' )
 		       ->with( 'avatar_rating' )
 		       ->andReturn( false );


### PR DESCRIPTION
Reverts 10up/simple-local-avatars#216

After the internal discussion, we are reverting #216 to fix the issues generated after that PR.

Closes #245, Closes #246

### How to test the Change

- Test the issues and see if those are resolved. 

### Changelog Entry
> Fixed - Reverting the Host/Doman support for local avatar URL after seeing new regressions

### Credits
Props @jakekackson1 @leogermani @dkotter @faisal-alvi 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
