### PR TITLE
Tweak/199 Move `simple_local_avatar_deleted` action to `avatar_delete`

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1132,15 +1132,6 @@ class Simple_Local_Avatars {
 
 			$this->avatar_delete( $user_id );    // delete old images if successful
 
-			/**
-			 * Enable themes and other plugins to react to avatar deletions.
-			 *
-			 * @since 2.6.0
-			 *
-			 * @param int $user_id Id of the user who's avatar was deleted.
-			 */
-			do_action( 'simple_local_avatar_deleted', $user_id );
-
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 				echo wp_kses_post( get_simple_local_avatar( $user_id ) );
 			}
@@ -1204,6 +1195,15 @@ class Simple_Local_Avatars {
 
 		delete_user_meta( $user_id, $this->user_key );
 		delete_user_meta( $user_id, $this->rating_key );
+
+		/**
+		 * Enable themes and other plugins to react to avatar deletions.
+		 *
+		 * @since 2.6.0
+		 *
+		 * @param int $user_id Id of the user who's avatar was deleted.
+		 */
+		do_action( 'simple_local_avatar_deleted', $user_id );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Simply moving the `simple_local_avatar_deleted` action to `avatar_delete`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #199

### How to test the Change



### Changelog Entry
> Changed -  Move `simple_local_avatar_deleted` action to `avatar_delete`

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @lllopo, @jeffpaul, @faisal-alvi 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
