### PR TITLE
Fix/231 Broken default avatar when `Local Avatars Only` is unchecked

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -275,7 +275,7 @@ class Simple_Local_Avatars {
 		}
 
 		// Local only mode
-		if ( ! $simple_local_avatar_url && ! empty( $this->options['only'] ) ) {
+		if ( ! $simple_local_avatar_url ) {
 			$args['url'] = $this->get_default_avatar_url( $args['size'] );
 		}
 


### PR DESCRIPTION
### Description of the Change

When the 'Local Avatars Only' setting is unchecked (i.e., disabled), the 'Default Avatar' setting was not being applied. Consequently, the gravatar was returned for images when no original image was set, resulting in broken avatars for users whose gravatar was not set.

This PR addresses this issue by displaying the 'Default Avatar' even when the 'Local Avatars Only' setting is disabled.

![image](https://github.com/10up/simple-local-avatars/assets/25176325/78a92c94-5e3d-43d3-ba84-566707f203e8)

## before

![image](https://github.com/10up/simple-local-avatars/assets/25176325/edc3f30a-5333-400f-991f-e20f57ce14c9)

## after

![image](https://github.com/10up/simple-local-avatars/assets/25176325/ce1fcb3b-4618-4820-9a3a-87bd7ff57a89)

Closes #231

### How to test the Change

1. Go to the avatar settings `/wp-admin/options-discussion.php`.
2. Choose the option to upload a custom image as your avatar.
3. Upload a custom image.
4. Make sure to untick the `Local Avatars Only` option.
5. Save the changes.
6. View the user's profile or avatar in various parts of the system.
7. There should not be any broken avatar images and the default avatar image should be shown as a fallback image.

### Changelog Entry
> Fixed - Broken default avatar when ' Local Avatars Only` is unchecked.

### Credits
Props @ankitguptaindia @faisal-alvi 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
