### PR TITLE
Fix - #224 Avoid php warnings

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -347,7 +347,7 @@ class Simple_Local_Avatars {
 		$all_avatar_ratings = ! empty( $this->avatar_ratings ) && is_array( $this->avatar_ratings )
 			? $this->avatar_ratings
 			: array();
-		if ( ! empty( $avatar_rating ) && 'G' !== $avatar_rating && $site_rating && $all_avatar_ratings ) {
+		if ( ! empty( $avatar_rating ) && 'G' !== $avatar_rating && $site_rating ) {
 			$ratings              = array_keys( $all_avatar_ratings );
 			$site_rating_weight   = array_search( $site_rating, $ratings, true );
 			$avatar_rating_weight = array_search( $avatar_rating, $ratings, true );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -342,10 +342,13 @@ class Simple_Local_Avatars {
 		}
 
 		// check rating
-		$avatar_rating = get_user_meta( $user_id, $this->rating_key, true );
-		$site_rating   = get_option( 'avatar_rating' );
-		if ( ! empty( $avatar_rating ) && 'G' !== $avatar_rating && $site_rating ) {
-			$ratings              = array_keys( $this->avatar_ratings );
+		$avatar_rating      = get_user_meta( $user_id, $this->rating_key, true );
+		$site_rating        = get_option( 'avatar_rating' );
+		$all_avatar_ratings = ! empty( $this->avatar_ratings ) && is_array( $this->avatar_ratings )
+			? $this->avatar_ratings
+			: array();
+		if ( ! empty( $avatar_rating ) && 'G' !== $avatar_rating && $site_rating && $all_avatar_ratings ) {
+			$ratings              = array_keys( $all_avatar_ratings );
 			$site_rating_weight   = array_search( $site_rating, $ratings, true );
 			$avatar_rating_weight = array_search( $avatar_rating, $ratings, true );
 			if ( false !== $avatar_rating_weight && $avatar_rating_weight > $site_rating_weight ) {


### PR DESCRIPTION
### Description of the Change
Add checks to avoid PHP warnings.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #224

### How to test the Change
- I was not able to replicate the warning. But it is good to add checks, especially for the array for php8.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Possible PHP warning


### Credits
Props @dkotter


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
