### PR TITLE
Bump WordPress "tested up to" version 6.5

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.3'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,7 @@
 Contributors:      jakemgold, 10up, thinkoomph, jeffpaul, faisal03
 Donate link:       https://10up.com/plugins/simple-local-avatars-wordpress/
 Tags:              avatar, gravatar, user photos, users, profile
-Requires at least: 5.7
-Tested up to:      6.4
-Requires PHP:      7.4
+Tested up to:      6.5
 Stable tag:        2.7.7
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-local-avatars.php
+++ b/simple-local-avatars.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://10up.com/plugins/simple-local-avatars-wordpress/
  * Description:       Adds an avatar upload field to user profiles. Generates requested sizes on demand, just like Gravatar! Simple and lightweight.
  * Version:           2.7.7
- * Requires at least: 5.7
+ * Requires at least: 6.3
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR bumps the WP tested-up-to version 6.5, bumps the WP min to 6.3, and removes [unnecessary headers](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/) from readme.txt.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #262.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.5.
> Changed - Bump WordPress minimum from 5.7 to 6.3.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sudip-md, @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
