### PR TITLE
Remove sanitizing for get_simple_local_avatar()

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -913,7 +913,7 @@ class Simple_Local_Avatars {
 							<div id="simple-local-avatar-photo" class="image-container" style="width: 100px; height: 100px; display: flex; align-items: center; justify-content: center; flex-direction: column;">
 								<?php
 								add_filter( 'pre_option_avatar_rating', '__return_empty_string' );     // ignore ratings here
-								echo wp_kses_post( get_simple_local_avatar( $profileuser->ID ) );
+								echo get_simple_local_avatar( $profileuser->ID );
 								remove_filter( 'pre_option_avatar_rating', '__return_empty_string' );
 								?>
 								<span class="spinner" id="simple-local-avatar-spinner"></span>
@@ -1136,7 +1136,7 @@ class Simple_Local_Avatars {
 			$this->avatar_delete( $user_id );    // delete old images if successful
 
 			if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-				echo wp_kses_post( get_simple_local_avatar( $user_id ) );
+				echo get_simple_local_avatar( $user_id );
 			}
 		}
 
@@ -1162,7 +1162,7 @@ class Simple_Local_Avatars {
 			$this->assign_new_user_avatar( $media_id, $user_id );
 		}
 
-		echo wp_kses_post( get_simple_local_avatar( $user_id ) );
+		echo get_simple_local_avatar( $user_id );
 
 		die;
 	}

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -353,10 +353,6 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		       ->with( 1 )
 		       ->andReturn( '<img src="test-image-user-avatar"/>' );
 
-		WP_Mock::userFunction( 'wp_kses_post' )
-		       ->with( '<img src="test-image-user-avatar"/>' )
-		       ->andReturn( '<img src="test-image-user-avatar"/>' );
-
 		$profileuser     = new stdClass();
 		$profileuser->ID = 1;
 


### PR DESCRIPTION
### Description of the Change
Removes the superfluous use of `wp_kses_post()` which currently removes required attributes provided by `get_avatar()`.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #272

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed - Ensure high-quality avatar preview on profile edit screen


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ocean90


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
