### PR TITLE
Fix Default Avatar Fallback (Param: `default` vs `url`)

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -276,11 +276,15 @@ class Simple_Local_Avatars {
 
 		// Local only mode
 		if ( ! $simple_local_avatar_url ) {
-			$default_url = $this->get_default_avatar_url( $args['size'] );
+			$default_url    = $this->get_default_avatar_url( $args['size'] );
+			$avatar_default = get_option( 'avatar_default' );
+
 			if ( ! empty( $this->options['only'] ) ) {
 				$args['url'] = $default_url;
-			} else {
+			} elseif ( 'simple_local_avatar' === $avatar_default ) {
 				$args['default'] = $default_url;
+			} else {
+				$args['url'] = $default_url;
 			}
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -283,6 +283,7 @@ class Simple_Local_Avatars {
 				$args['url'] = $default_url;
 			} elseif ( 'simple_local_avatar' === $avatar_default ) {
 				$args['default'] = $default_url;
+			}
 		}
 
 		if ( ! empty( $args['url'] ) ) {

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -283,9 +283,6 @@ class Simple_Local_Avatars {
 				$args['url'] = $default_url;
 			} elseif ( 'simple_local_avatar' === $avatar_default ) {
 				$args['default'] = $default_url;
-			} else {
-				$args['url'] = $default_url;
-			}
 		}
 
 		if ( ! empty( $args['url'] ) ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

In #278, we fixed 2 issues as [discussed](https://10up.slack.com/archives/CG6QB7HEU/p1715629417260779?thread_ts=1715523810.003639&cid=CG6QB7HEU) on the slack but there is [one more scenario](https://wordpress.org/support/topic/gravatar-avatars-not-working/page/2/#post-17754560) we should handle.

Solution in this PR: The `default` parameter should be used only when the default avatar is set from the Media Library images.

<p>Technically, we utilize the <code class="notranslate rich-diff-level-one">url</code> parameter to establish the default (fallback) avatar when the "Local only" setting is enabled, and we use the <code class="notranslate rich-diff-level-one">default</code> parameter when it's disabled. However, when it's disabled and, for instance, the RoboHash option is selected as the default avatar, WordPress core invariably checks for the <code class="notranslate rich-diff-level-one">url</code> parameter and finds it empty, thus defaulting to the Gravatar logo as reported, bypassing the avatar set via the <code class="notranslate rich-diff-level-one">default</code> parameter. </p>

<p>We have now realized that this is a complex flow because we introduced an option to select an actual image from the media library since #96. However, WordPress core is configured to utilize default avatars based solely on their respective names (e.g., mystery, blank, retro), taking these strings in the <code class="notranslate rich-diff-level-one">default</code> parameter. Now, after #96, we must pass the full image URL in <code class="notranslate rich-diff-level-one">default</code>, which has added complexity to this flow and requires careful handling. Ultimately, with this PR, we're appropriately (and hopefully) managing all scenarios with multiple conditions and utilizing the <code class="notranslate rich-diff-level-one">default</code> versus <code class="notranslate rich-diff-level-one">url</code> parameter according to the settings.</p>

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://wordpress.org/support/topic/gravatar-avatars-not-working/page/2/#post-17754560

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed - Default Avatar (like RoboHash) always fallback to Gravatar Logo

### Credits
Props @faisal-alvi

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
