### PR TITLE
fix: user meta retrieval

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -358,7 +358,7 @@ class Simple_Local_Avatars {
 
 		// Fetch local avatar from meta and make sure it's properly set.
 		$local_avatars = $this->get_user_local_avatar( $user_id );
-		if ( empty( $local_avatars['full'] ) ) {
+		if ( ! isset( $local_avatars['full'] ) ||empty( $local_avatars['full'] ) ) {
 			return '';
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -332,7 +332,7 @@ class Simple_Local_Avatars {
 	 * @param int $user_id User ID.
 	 * @return array Array with avatar data.
 	 */
-	public static function get_user_local_avatar( $user ) {
+	public function get_user_local_avatar( $user_id ) {
 		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
 		if ( ! is_array( $local_avatars ) || empty( $local_avatars ) ) {
 			return [];
@@ -357,7 +357,7 @@ class Simple_Local_Avatars {
 		}
 
 		// Fetch local avatar from meta and make sure it's properly set.
-		$local_avatars = self::get_user_local_avatar( $user_id );
+		$local_avatars = $this->get_user_local_avatar( $user_id );
 		if ( empty( $local_avatars['full'] ) ) {
 			return '';
 		}
@@ -493,7 +493,7 @@ class Simple_Local_Avatars {
 		}
 
 		// Fetch local avatar from meta and make sure we have a media ID.
-		$local_avatars = get_user_meta( $user_id, 'simple_local_avatar', true );
+		$local_avatars = $this->get_user_local_avatar( $user_id );
 		if ( empty( $local_avatars['media_id'] ) ) {
 			$alt = '';
 			// If no avatar is set, check if we are using a default avatar with alt text.
@@ -1125,7 +1125,7 @@ class Simple_Local_Avatars {
 		endif;
 
 		// Handle ratings
-		if ( isset( $avatar_id ) || get_user_meta( $user_id, $this->user_key, true ) ) {
+		if ( isset( $avatar_id ) || ! empty( $this->get_user_local_avatar( $user_id ) ) ) {
 			if ( empty( $_POST['simple_local_avatar_rating'] ) || ! array_key_exists( $_POST['simple_local_avatar_rating'], $this->avatar_ratings ) ) {
 				$_POST['simple_local_avatar_rating'] = key( $this->avatar_ratings );
 			}
@@ -1195,7 +1195,7 @@ class Simple_Local_Avatars {
 	 * @param int $user_id User ID.
 	 */
 	public function avatar_delete( $user_id ) {
-		$old_avatars = self::get_user_local_avatar( $user_id );
+		$old_avatars = $this->get_user_local_avatar( $user_id );
 
 		if ( empty( $old_avatars ) ) {
 			return;
@@ -1286,7 +1286,7 @@ class Simple_Local_Avatars {
 	 * @param object $user User object
 	 */
 	public function get_avatar_rest( $user ) {
-		$local_avatar = get_user_meta( $user['id'], $this->user_key, true );
+		$local_avatar = $this->get_user_local_avatar( $user['id'] );
 		if ( empty( $local_avatar ) ) {
 			return;
 		}
@@ -1411,7 +1411,7 @@ class Simple_Local_Avatars {
 		if ( ! empty( $users ) ) {
 			foreach ( $users as $user ) {
 				$user_id       = $user->ID;
-				$local_avatars = get_user_meta( $user_id, 'simple_local_avatar', true );
+				$local_avatars = $this->get_user_local_avatar( $user_id );
 				$media_id      = isset( $local_avatars['media_id'] ) ? $local_avatars['media_id'] : '';
 				$this->clear_user_avatar_cache( $local_avatars, $user_id, $media_id );
 			}

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -358,7 +358,7 @@ class Simple_Local_Avatars {
 
 		// Fetch local avatar from meta and make sure it's properly set.
 		$local_avatars = $this->get_user_local_avatar( $user_id );
-		if ( ! isset( $local_avatars['full'] ) ||empty( $local_avatars['full'] ) ) {
+		if ( ! isset( $local_avatars['full'] ) || empty( $local_avatars['full'] ) ) {
 			return '';
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -327,6 +327,20 @@ class Simple_Local_Avatars {
 	}
 
 	/**
+	 * Get the local avatar user meta.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array Array with avatar data.
+	 */
+	public static function get_user_local_avatar( $user ) {
+		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
+		if ( ! is_array( $local_avatars ) || empty( $local_avatars ) ) {
+			return [];
+		}
+		return $local_avatars;
+	}
+
+	/**
 	 * Get local avatar url.
 	 *
 	 * @since 2.2.0
@@ -343,7 +357,7 @@ class Simple_Local_Avatars {
 		}
 
 		// Fetch local avatar from meta and make sure it's properly set.
-		$local_avatars = get_user_meta( $user_id, $this->user_key, true );
+		$local_avatars = self::get_user_local_avatar( $user_id );
 		if ( empty( $local_avatars['full'] ) ) {
 			return '';
 		}
@@ -1181,7 +1195,7 @@ class Simple_Local_Avatars {
 	 * @param int $user_id User ID.
 	 */
 	public function avatar_delete( $user_id ) {
-		$old_avatars = (array) get_user_meta( $user_id, $this->user_key, true );
+		$old_avatars = self::get_user_local_avatar( $user_id );
 
 		if ( empty( $old_avatars ) ) {
 			return;

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -494,7 +494,7 @@ class Simple_Local_Avatars {
 
 		// Fetch local avatar from meta and make sure we have a media ID.
 		$local_avatars = $this->get_user_local_avatar( $user_id );
-		if ( empty( $local_avatars['media_id'] ) ) {
+		if ( ! isset( $local_avatars['media_id'] ) || empty( $local_avatars['media_id'] ) ) {
 			$alt = '';
 			// If no avatar is set, check if we are using a default avatar with alt text.
 			if ( 'simple_local_avatar' === get_option( 'avatar_default' ) ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

Add sanity checks to the user meta values read from the DB. We've seen this user data malformatted – maybe it was in migration from another WP instance. 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Directly in the DB, update the `simple_local_avatar` meta of a user to an empty string
2. Update the `simple_local_avatar` meta of another user to an object (e.g. `update_user_meta(<id>, 'simple_local_avatar', (object) ['value' => 42])`)
3. Observe that these changes crash the site on `develop` branch 
4. Switch to this branch, observe the site is not crashing

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Handling of malformed `simple_local_avatar` user meta.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
