### PR TITLE
Add a `current_user_can` check to our cache clearing method

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1388,6 +1388,13 @@ class Simple_Local_Avatars {
 	 */
 	public function sla_clear_user_cache() {
 		check_ajax_referer( 'sla_clear_cache_nonce', 'nonce' );
+
+		// Ensure this was run by a user with proper privileges.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			// Match what `check_ajax_referer` does.
+			wp_die( -1, 403 );
+		}
+
 		$step = isset( $_REQUEST['step'] ) ? intval( $_REQUEST['step'] ) : 1;
 
 		// Setup defaults.


### PR DESCRIPTION
### Description of the Change

In #90 we introduced an admin setting that allows on-demand clearing of avatar cache, useful for situations where image sizes have changed and SLA still has the old image sizes stored.

This setting outputs a button that when clicked, fires an AJAX request to kick off the cache clearing process. This request does pass and validate a proper nonce but doesn't have any user capability check. This means in theory anyone that has a user account on the site can generate a nonce and make a direct request to the proper AJAX endpoint to trigger that cache clearing.

This PR fixes that by adding a `current_user_can( 'manage_options' )` check, as only users with that capability can access the `Settings > Discussion` page to begin with and thus should be the only ones that can initiate this cache clearing.

### How to test the Change

1. Go to `Settings > Discussion`
2. Scroll down to the `Clear local avatar cache` setting and click the `Clear cache` button
3. Ensure this process works as expected

The test above ensures things still work as expected but does not verify things are more secure. If desired, can provide details on how to test that, which requires making direct requests to the AJAX endpoint.

### Changelog Entry

> Security - Run a user capability check before we clear the avatar cache.

### Credits

Props @dkotter, @truonghuuphuc

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
