### PR TITLE
Additional avatar REST checks

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1324,8 +1324,14 @@ class Simple_Local_Avatars {
 			return new \WP_Error( 'invalid_media_id', esc_html__( 'Request did not contain a valid media_id field.', 'simple-local-avatars' ) );
 		}
 
+		$attachment = get_post( (int) $input['media_id'] );
+
 		// Ensure this media_id is a valid attachment.
-		if ( ! wp_get_attachment_url( (int) $input['media_id'] ) ) {
+		if (
+			! $attachment ||
+			'attachment' !== $attachment->post_type ||
+			! wp_attachment_is_image( $attachment )
+		) {
 			return new \WP_Error( 'invalid_media_id', esc_html__( 'Media ID did not match a valid attachment.', 'simple-local-avatars' ) );
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1335,6 +1335,11 @@ class Simple_Local_Avatars {
 			return new \WP_Error( 'invalid_media_id', esc_html__( 'Media ID did not match a valid attachment.', 'simple-local-avatars' ) );
 		}
 
+		// Ensure this attachment is associated with this user.
+		if ( (int) $attachment->post_author !== (int) $user->ID ) {
+			return new \WP_Error( 'invalid_media_id', esc_html__( 'This attachment was not uploaded by this user.', 'simple-local-avatars' ) );
+		}
+
 		$this->assign_new_user_avatar( (int) $input['media_id'], $user->ID );
 	}
 


### PR DESCRIPTION
### Description of the Change

Users with access to the `user` REST endpoint can use that to set their avatar. Additional checks were added in the last release but a few other areas of concern came up:

1. We allow any valid attachment ID to be set, including things like PDFs or videos. We change that here to ensure the attachment ID is associated with an image only
2. Any valid attachment ID can be used, even if that ID wasn't an image uploaded by the user. We change that here to only proceed if the attachment ID they are using is an attachment associated with their account. This means any images uploaded by another user aren't allowed to be used

> [!NOTE]
> While these changes make things more secure, this could be seen as a breaking change if someone is used to a workflow where one user uploads images and other users then set those images as their avatar via a REST request. I can't imagine that's common (if anyone is doing that at all) but worth flagging

### How to test the Change

Make authenticated requests to the `user` endpoint, passing in the proper data and ensuring the avatar gets set correctly and rejected correctly. For instance, try passing in an attachment ID that doesn't exit, that does exist but isn't an image, that is an image that your user uploaded, that is an image that a different user uploaded. Ping me for full details if needed.

### Changelog Entry

> Changed - Only allow images that were uploaded by the same user be used when setting the avatar via a REST request
> Fixed - Only allow image files to be set as the avatar in REST requests

### Credits

Props @dkotter, @justus12337

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
