### PR TITLE
Don't create duplicate image sizes

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -437,20 +437,23 @@ class Simple_Local_Avatars {
 				// generate the new size
 				$editor = wp_get_image_editor( $avatar_full_path );
 				if ( ! is_wp_error( $editor ) ) {
-					$resized = $editor->resize( $size, $size, true );
-					if ( ! is_wp_error( $resized ) ) {
-						$dest_file = $editor->generate_filename();
-						$saved     = $editor->save( $dest_file );
-						if ( ! is_wp_error( $saved ) ) {
-							// Transform the destination file path into URL.
-							$dest_file_url = '';
-							if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
-								$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
-							} elseif ( is_multisite() && false !== strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
-								$dest_file_url = str_replace( ABSPATH . 'wp-content/uploads', network_site_url( '/wp-content/uploads' ), $dest_file );
-							}
+					$image_size = $editor->get_size();
+					if ( $image_size['width'] !== $size || $image_size['height'] !== $size ) {
+						$resized = $editor->resize( $size, $size, true );
+						if ( ! is_wp_error( $resized ) ) {
+							$dest_file = $editor->generate_filename();
+							$saved     = $editor->save( $dest_file );
+							if ( ! is_wp_error( $saved ) ) {
+								// Transform the destination file path into URL.
+								$dest_file_url = '';
+								if ( false !== strpos( $dest_file, $upload_path['basedir'] ) ) {
+									$dest_file_url = str_replace( $upload_path['basedir'], $upload_path['baseurl'], $dest_file );
+								} elseif ( is_multisite() && false !== strpos( $dest_file, ABSPATH . 'wp-content/uploads' ) ) {
+									$dest_file_url = str_replace( ABSPATH . 'wp-content/uploads', network_site_url( '/wp-content/uploads' ), $dest_file );
+								}
 
-							$local_avatars[ $size ] = $dest_file_url;
+								$local_avatars[ $size ] = $dest_file_url;
+							}
 						}
 					}
 				}

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -438,7 +438,7 @@ class Simple_Local_Avatars {
 				$editor = wp_get_image_editor( $avatar_full_path );
 				if ( ! is_wp_error( $editor ) ) {
 					$image_size = $editor->get_size();
-					if ( $image_size['width'] !== $size || $image_size['height'] !== $size ) {
+					if ( ! $image_size || $image_size['width'] !== $size || $image_size['height'] !== $size ) {
 						$resized = $editor->resize( $size, $size, true );
 						if ( ! is_wp_error( $resized ) ) {
 							$dest_file = $editor->generate_filename();

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -438,7 +438,7 @@ class Simple_Local_Avatars {
 				$editor = wp_get_image_editor( $avatar_full_path );
 				if ( ! is_wp_error( $editor ) ) {
 					$image_size = $editor->get_size();
-					if ( ! $image_size || $image_size['width'] !== $size || $image_size['height'] !== $size ) {
+					if ( ! is_array( $image_size ) || $image_size['width'] !== $size || $image_size['height'] !== $size ) {
 						$resized = $editor->resize( $size, $size, true );
 						if ( ! is_wp_error( $resized ) ) {
 							$dest_file = $editor->generate_filename();


### PR DESCRIPTION
### Description of the Change
Check size of original image before creating a duplicate version of it.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #323

### How to test the Change
Upload an image of an avatar size that is used on the site. Ensure that no version is created for this size.

### Changelog Entry
> Changed - Don't create duplicate image sizes

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ocean90 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
