### PR TITLE
Update `blueprint.json` to remove/fix deprecated properties and add hash to URL

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,22 +1,20 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
-	"landingPage": "\/wp-admin\/options-discussion.php",
+	"landingPage": "\/wp-admin\/options-discussion.php#show_avatars",
 	"preferredVersions": {
 		"php": "7.4",
 		"wp": "latest"
 	},
-	"phpExtensionBundles": ["kitchen-sink"],
 	"features": {
 		"networking": true
 	},
 	"steps": [
 		{
 			"step": "login",
-			"username": "admin",
-			"password": "password"
+			"username": "admin"
 		},
 		{
-			"step": "importFile",
+			"step": "importWxr",
 			"file": {
 				"resource": "url",
 				"url": "https:\/\/raw.githubusercontent.com\/10up\/simple-local-avatars\/073f1979d6addeb3eecd7fb8cf56efe9bcfa7007\/.wordpress-org\/blueprints\/demo-data.xml"
@@ -24,7 +22,7 @@
 		},
 		{
 			"step": "installPlugin",
-			"pluginZipFile": {
+			"pluginData": {
 				"resource": "wordpress.org\/plugins",
 				"slug": "simple-local-avatars"
 			},


### PR DESCRIPTION
### Description of the Change

I was recently pinged on https://github.com/WordPress/wordpress-playground/issues/909, which I had opened to report an issue in a blueprint file that uses a hash in the landing page URL. We wanted to use that here to automatically link someone to the correct section on the Discussion settings page.

It seems that has no been fixed so this PR adds that hash back in. In addition, noticed we are using a few properties that have since been deprecated so either removed those entirely or replaced those with the proper values.

### How to test the Change

The following URL will load an environment with the blueprint from this PR. Ensure this environment works as expected:

https://playground.wordpress.net/#{%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin/options-discussion.php#show_avatars%22,%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%22latest%22},%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22},{%22step%22:%22importWxr%22,%22file%22:{%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/10up/simple-local-avatars/073f1979d6addeb3eecd7fb8cf56efe9bcfa7007/.wordpress-org/blueprints/demo-data.xml%22}},{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22simple-local-avatars%22},%22options%22:{%22activate%22:true}},{%22step%22:%22setSiteOptions%22,%22options%22:{%22avatar_default%22:%22simple_local_avatar%22,%22simple_local_avatars%22:{%22caps%22:1,%22only%22:1},%22simple_local_avatar_default%22:5}}]}

### Changelog Entry

> Developer - Update our blueprint file to remove deprecated properties and change our landing page URL to point to the proper hash

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
