### PR TITLE
Ensure the release asset can be attached properly

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   packages: read
   id-token: write
 


### PR DESCRIPTION
### Description of the Change

After the last release (2.8.4), an error occured when our GitHub Action tried to attach the final release asset to the release (see https://github.com/10up/simple-local-avatars/actions/runs/16271766801). This is due to permission changes we made in #337. This PR updates the permissions there to ensure this works properly.

### How to test the Change

Nothing really to test here

### Changelog Entry

> Developer - Ensure our final release asset gets attached properly to the release

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
