### PR TITLE
Coding standards review

### DIFF
--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -145,26 +145,26 @@ class Simple_Local_Avatars {
 			}, 10, 1 );
 		}
 
-		/*
-		 * Fix: An error occurred cropping the image
-		 *
-		 * @see https://github.com/10up/simple-local-avatars/issues/141
-		 * @see wp_ajax_crop_image() in wp-admin/includes/ajax-actions.php
-		 *
-		 * During a WordPress Core crop-image ajax request, bypass the theme_setup hook.
-		 */
-		if (
-			isset( $_POST['action'] )
-			&& 'crop-image' === $_POST['action']
-			&& isset( $_POST['id'] )
-			&& is_admin()
-			&& wp_doing_ajax()
-			&& check_ajax_referer( 'image_editor-' . absint( $_POST['id'] ), 'nonce', false )
-		) {
-			add_action( 'plugins_loaded', function () {
+		add_action( 'plugins_loaded', function () {
+			/*
+			* Fix: An error occurred cropping the image
+			*
+			* @see https://github.com/10up/simple-local-avatars/issues/141
+			* @see wp_ajax_crop_image() in wp-admin/includes/ajax-actions.php
+			*
+			* During a WordPress Core crop-image ajax request, bypass the theme_setup hook.
+			*/
+			if (
+				isset( $_POST['action'] )
+				&& 'crop-image' === $_POST['action']
+				&& isset( $_POST['id'] )
+				&& is_admin()
+				&& wp_doing_ajax()
+				&& check_ajax_referer( 'image_editor-' . absint( $_POST['id'] ), 'nonce', false )
+			) {
 				remove_all_actions( 'setup_theme' );
-			} );
-		}
+			}
+		} );
 	}
 
 	/**

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -145,26 +145,29 @@ class Simple_Local_Avatars {
 			}, 10, 1 );
 		}
 
-		add_action( 'plugins_loaded', function () {
-			/*
-			* Fix: An error occurred cropping the image
-			*
-			* @see https://github.com/10up/simple-local-avatars/issues/141
-			* @see wp_ajax_crop_image() in wp-admin/includes/ajax-actions.php
-			*
-			* During a WordPress Core crop-image ajax request, bypass the theme_setup hook.
-			*/
-			if (
-				isset( $_POST['action'] )
-				&& 'crop-image' === $_POST['action']
-				&& isset( $_POST['id'] )
-				&& is_admin()
-				&& wp_doing_ajax()
-				&& check_ajax_referer( 'image_editor-' . absint( $_POST['id'] ), 'nonce', false )
-			) {
-				remove_all_actions( 'setup_theme' );
+		add_action(
+			'plugins_loaded',
+			function () {
+				/*
+				* Fix: An error occurred cropping the image
+				*
+				* @see https://github.com/10up/simple-local-avatars/issues/141
+				* @see wp_ajax_crop_image() in wp-admin/includes/ajax-actions.php
+				*
+				* During a WordPress Core crop-image ajax request, bypass the theme_setup hook.
+				*/
+				if (
+					isset( $_POST['action'] )
+					&& 'crop-image' === $_POST['action']
+					&& isset( $_POST['id'] )
+					&& is_admin()
+					&& wp_doing_ajax()
+					&& check_ajax_referer( 'image_editor-' . absint( $_POST['id'] ), 'nonce', false )
+				) {
+					remove_all_actions( 'setup_theme' );
+				}
 			}
-		} );
+		);
 	}
 
 	/**

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -145,8 +145,19 @@ class Simple_Local_Avatars {
 			}, 10, 1 );
 		}
 
-		// Fix: An error occurred cropping the image (https://github.com/10up/simple-local-avatars/issues/141).
-		if ( isset( $_POST['action'] ) && 'crop-image' === $_POST['action'] && is_admin() && wp_doing_ajax() ) {
+		/*
+		 * Fix: An error occurred cropping the image
+		 *
+		 * @see https://github.com/10up/simple-local-avatars/issues/141
+		 *
+		 * During a WordPress Core crop-image ajax request, bypass the theme_setup hook.
+		 */
+		if (
+			isset( $_POST['action'] )
+			&& 'crop-image' === $_POST['action']
+			&& is_admin()
+			&& wp_doing_ajax()
+		) {
 			add_action( 'plugins_loaded', function () {
 				remove_all_actions( 'setup_theme' );
 			} );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -74,7 +74,8 @@ class Simple_Local_Avatars {
 			&& (
 				( // And either an ajax request not in the network admin.
 					defined( 'DOING_AJAX' ) && DOING_AJAX
-					&& isset( $_SERVER['HTTP_REFERER'] ) && ! preg_match( '#^' . network_admin_url() . '#i', $_SERVER['HTTP_REFERER'] )
+					&& isset( $_SERVER['HTTP_REFERER'] )
+					&& ! preg_match( '#^' . preg_quote( network_admin_url(), '#' ) . '#i', $_SERVER['HTTP_REFERER'] )
 				)
 				||
 				( // Or normal request not in the network admin.

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1093,8 +1093,9 @@ class Simple_Local_Avatars {
 
 			// need to be more secure since low privilege users can upload
 			$allowed_mime_types = wp_get_mime_types();
-			$file_mime_type     = strtolower( $_FILES['simple-local-avatar']['type'] );
 
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- validated in following lines.
+			$file_mime_type = strtolower( $_FILES['simple-local-avatar']['type'] );
 			if ( ! ( 0 === strpos( $file_mime_type, 'image/' ) ) || ! in_array( $file_mime_type, $allowed_mime_types, true ) ) {
 				$this->avatar_upload_error = __( 'Only images can be uploaded as an avatar', 'simple-local-avatars' );
 				add_action( 'user_profile_update_errors', array( $this, 'user_profile_update_errors' ) );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1587,6 +1587,11 @@ class Simple_Local_Avatars {
 			return;
 		}
 
+		// Ensure user has proper capability.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		$file_id = filter_input( INPUT_POST, 'simple-local-avatar-file-id', FILTER_SANITIZE_NUMBER_INT );
 
 		// check for uploaded files

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1148,11 +1148,13 @@ class Simple_Local_Avatars {
 
 		// Handle ratings
 		if ( isset( $avatar_id ) || ! empty( $this->get_user_local_avatar( $user_id ) ) ) {
-			if ( empty( $_POST['simple_local_avatar_rating'] ) || ! array_key_exists( $_POST['simple_local_avatar_rating'], $this->avatar_ratings ) ) {
-				$_POST['simple_local_avatar_rating'] = key( $this->avatar_ratings );
+			$passed_avatar_rating = isset( $_POST['simple_local_avatar_rating'] ) ? sanitize_text_field( wp_unslash( $_POST['simple_local_avatar_rating'] ) ) : '';
+			if ( empty( $passed_avatar_rating ) || ! in_array( $passed_avatar_rating, array_keys( $this->avatar_ratings ), true ) ) {
+				$passed_avatar_rating                = key( $this->avatar_ratings );
+				$_POST['simple_local_avatar_rating'] = wp_slash( $passed_avatar_rating ); // May be access later in execution.
 			}
 
-			update_user_meta( $user_id, $this->rating_key, $_POST['simple_local_avatar_rating'] );
+			update_user_meta( $user_id, $this->rating_key, wp_slash( $passed_avatar_rating ) );
 		}
 	}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1081,7 +1081,7 @@ class Simple_Local_Avatars {
 	 */
 	public function edit_user_profile_update( $user_id ) {
 		// check nonces
-		if ( empty( $_POST['_simple_local_avatar_nonce'] ) || ! wp_verify_nonce( $_POST['_simple_local_avatar_nonce'], 'simple_local_avatar_nonce' ) ) {
+		if ( empty( $_POST['_simple_local_avatar_nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['_simple_local_avatar_nonce'] ), 'simple_local_avatar_nonce' ) ) {
 			return;
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -790,15 +790,18 @@ class Simple_Local_Avatars {
 		$sanitized = array();
 
 		foreach ( $options as $option_name ) {
-			if ( ! isset( $_POST['simple_local_avatars'][ $option_name ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			// phpcs:ignore WordPress.Security.NonceVerification -- checked by wp-admin/network/settings.php
+			if ( ! isset( $_POST['simple_local_avatars'][ $option_name ] ) ) {
 				continue;
 			}
 
 			switch ( $option_name ) {
 				case 'mode':
-					update_site_option( 'simple_local_avatars_mode', sanitize_text_field( $_POST['simple_local_avatars'][ $option_name ] ) );
+					// phpcs:ignore WordPress.Security.NonceVerification -- checked by wp-admin/network/settings.php
+					update_site_option( 'simple_local_avatars_mode', sanitize_text_field( wp_unslash( $_POST['simple_local_avatars'][ $option_name ] ) ) );
 					break;
 				default:
+					// phpcs:ignore WordPress.Security.NonceVerification -- checked by wp-admin/network/settings.php
 					$sanitized[ $option_name ] = empty( $_POST['simple_local_avatars'][ $option_name ] ) ? 0 : 1;
 			}
 		}

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1196,7 +1196,14 @@ class Simple_Local_Avatars {
 	 */
 	public function ajax_assign_simple_local_avatar_media() {
 		// check required information and permissions
-		if ( empty( $_POST['user_id'] ) || empty( $_POST['media_id'] ) || ! current_user_can( 'upload_files' ) || ! current_user_can( 'edit_user', $_POST['user_id'] ) || empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'assign_simple_local_avatar_nonce' ) ) {
+		if (
+			empty( $_POST['user_id'] )
+			|| empty( $_POST['media_id'] )
+			|| ! current_user_can( 'upload_files' )
+			|| ! current_user_can( 'edit_user', absint( wp_unslash( $_POST['user_id'] ) ) )
+			|| empty( $_POST['_wpnonce'] )
+			|| ! wp_verify_nonce( wp_unslash( $_POST['_wpnonce'] ), 'assign_simple_local_avatar_nonce' )
+		) {
 			die;
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -75,6 +75,7 @@ class Simple_Local_Avatars {
 				( // And either an ajax request not in the network admin.
 					defined( 'DOING_AJAX' ) && DOING_AJAX
 					&& isset( $_SERVER['HTTP_REFERER'] )
+					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- this validates rather than sanitizes
 					&& ! preg_match( '#^' . preg_quote( network_admin_url(), '#' ) . '#i', wp_unslash( $_SERVER['HTTP_REFERER'] ) )
 				)
 				||

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1700,7 +1700,7 @@ class Simple_Local_Avatars {
 		}
 
 		// Bail early if nonce is invalid.
-		if ( ! wp_verify_nonce( sanitize_text_field( $_POST['migrateFromWpUserAvatarNonce'] ), 'migrate_from_wp_user_avatar_nonce' ) ) {
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['migrateFromWpUserAvatarNonce'] ) ), 'migrate_from_wp_user_avatar_nonce' ) ) {
 			die();
 		}
 

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1172,7 +1172,7 @@ class Simple_Local_Avatars {
 	 * Runs when a user clicks the Remove button for the avatar
 	 */
 	public function action_remove_simple_local_avatar() {
-		if ( ! empty( $_GET['user_id'] ) && ! empty( $_GET['_wpnonce'] ) && wp_verify_nonce( $_GET['_wpnonce'], 'remove_simple_local_avatar_nonce' ) ) {
+		if ( ! empty( $_GET['user_id'] ) && ! empty( $_GET['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'remove_simple_local_avatar_nonce' ) ) {
 			$user_id = (int) $_GET['user_id'];
 
 			if ( ! current_user_can( 'edit_user', $user_id ) ) {

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -149,14 +149,17 @@ class Simple_Local_Avatars {
 		 * Fix: An error occurred cropping the image
 		 *
 		 * @see https://github.com/10up/simple-local-avatars/issues/141
+		 * @see wp_ajax_crop_image() in wp-admin/includes/ajax-actions.php
 		 *
 		 * During a WordPress Core crop-image ajax request, bypass the theme_setup hook.
 		 */
 		if (
 			isset( $_POST['action'] )
 			&& 'crop-image' === $_POST['action']
+			&& isset( $_POST['id'] )
 			&& is_admin()
 			&& wp_doing_ajax()
+			&& check_ajax_referer( 'image_editor-' . absint( $_POST['id'] ), 'nonce', false )
 		) {
 			add_action( 'plugins_loaded', function () {
 				remove_all_actions( 'setup_theme' );

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -75,7 +75,7 @@ class Simple_Local_Avatars {
 				( // And either an ajax request not in the network admin.
 					defined( 'DOING_AJAX' ) && DOING_AJAX
 					&& isset( $_SERVER['HTTP_REFERER'] )
-					&& ! preg_match( '#^' . preg_quote( network_admin_url(), '#' ) . '#i', $_SERVER['HTTP_REFERER'] )
+					&& ! preg_match( '#^' . preg_quote( network_admin_url(), '#' ) . '#i', wp_unslash( $_SERVER['HTTP_REFERER'] ) )
 				)
 				||
 				( // Or normal request not in the network admin.

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -1695,7 +1695,7 @@ class Simple_Local_Avatars {
 		}
 
 		// Bail early if nonce is not available.
-		if ( empty( sanitize_text_field( $_POST['migrateFromWpUserAvatarNonce'] ) ) ) {
+		if ( empty( $_POST['migrateFromWpUserAvatarNonce'] ) ) {
 			die;
 		}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,13 @@
 			</property>
 		</properties>
 	</rule>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput">
+		<properties>
+			<property name="customSanitizingFunctions" type="array">
+				<element value="wp_verify_nonce"/> <!-- Character by character comparison, sanitization may "fix" a mismatch. -->
+			</property>
+		</properties>
+	</rule>
 	<file>.</file>
 	<exclude-pattern>dist/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0"?>
 <ruleset name="Project Rules">
 	<rule ref="10up-Default" />
+	<rule ref="WordPress.Security.EscapeOutput">
+		<properties>
+			<property name="customAutoEscapedFunctions" type="array">
+				<element value="get_simple_local_avatar"/> <!-- wrapper for safe get_avatar() -->
+			</property>
+		</properties>
+	</rule>
 	<file>.</file>
 	<exclude-pattern>dist/</exclude-pattern>
 	<exclude-pattern>vendor/</exclude-pattern>

--- a/tests/phpunit/SimpleLocalAvatarsTest.php
+++ b/tests/phpunit/SimpleLocalAvatarsTest.php
@@ -402,6 +402,10 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 		$_POST['simple_local_avatar_rating'] = '';
 		$_POST['_simple_local_avatar_nonce'] = 'not empty';
 
+		WP_Mock::passthruFunction( 'wp_unslash' );
+		WP_Mock::passthruFunction( 'wp_slash' );
+		WP_Mock::passthruFunction( 'sanitize_text_field' );
+
 		WP_Mock::userFunction( 'wp_verify_nonce' )
 		       ->with( $_POST['_simple_local_avatar_nonce'], 'simple_local_avatar_nonce' )
 		       ->andReturn( true );
@@ -416,6 +420,8 @@ class SimpleLocalAvatarsTest extends \WP_Mock\Tools\TestCase {
 	public function test_action_remove_simple_local_avatar() {
 		$_GET['user_id']  = 1;
 		$_GET['_wpnonce'] = 1;
+
+		WP_Mock::passthruFunction( 'wp_unslash' );
 
 		WP_Mock::userFunction( 'wp_verify_nonce' )
 		       ->with( $_GET['_wpnonce'], 'remove_simple_local_avatar_nonce' )


### PR DESCRIPTION
### Description of the Change

Minor hardening of code following limited review against WP and VIP Coding standards.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Fixed - Ensure form data is unslashed as required
> Changed - Consider get_avatar() wrapper function get_simple_local_avatar() escaped
> Changed - Consider wp_verify_nonce() as auto-sanitized
> Security - (Hardening) Ensure user has manage_option cap before saving default avatar.

### Credits
Props @peterwilsoncc 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
