### PR TITLE
Release/2.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+## [2.8.6] - 2026-02-17
+### Changed
+- Bump WordPress "tested up to" version 6.9 (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#352](https://github.com/10up/simple-local-avatars/pull/352)).
+- Consider `get_avatar()` wrapper function `get_simple_local_avatar()` escaped (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+- Consider `wp_verify_nonce()` as auto-sanitized (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+
+### Fixed
+- Ensure form data is unslashed as required (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+
+### Security
+- (Hardening) Ensure user has `manage_option` cap before saving default avatar (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+
+### Developer
+- Ensure our final release asset gets attached properly to the release (props [@dkotter](https://github.com/dkotter), [@jeffpaul](https://github.com/jeffpaul) via [#340](https://github.com/10up/simple-local-avatars/pull/340)).
+- Add Patchstack security-reporting FAQ (props [@jeffpaul](https://github.com/jeffpaul) via [#355](https://github.com/10up/simple-local-avatars/pull/355)).
+- Update dependencies via `npm audit fix` (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#354](https://github.com/10up/simple-local-avatars/pull/354)).
+- Bump `on-headers` from 1.0.2 to 1.1.0 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#341](https://github.com/10up/simple-local-avatars/pull/341)).
+- Bump `compression` from 1.7.5 to 1.8.1 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#341](https://github.com/10up/simple-local-avatars/pull/341)).
+- Bump `form-data` from 4.0.1 to 4.0.4 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#346](https://github.com/10up/simple-local-avatars/pull/346)).
+- Bump `tmp` from 0.2.3 to 0.2.5 (props [@dependabot](https://github.com/apps/dependabot), [@Sidsector9](hhttps://github.com/Sidsector9) via [#347](https://github.com/10up/simple-local-avatars/pull/347)).
+- Bump `@wordpress/env` from 10.11.0 to 10.28.0 (props [@dependabot](https://github.com/apps/dependabot), [@Sidsector9](hhttps://github.com/Sidsector9) via [#347](https://github.com/10up/simple-local-avatars/pull/347)).
+- Bump `playwright` from 1.48.2 to 1.56.1 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#350](https://github.com/10up/simple-local-avatars/pull/350)).
+- Bump `lodash` from 4.17.21 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#356](https://github.com/10up/simple-local-avatars/pull/356)).
+- Bump `lodash-es` from 4.17.22 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#357](https://github.com/10up/simple-local-avatars/pull/357)).
+
 ## [2.8.5] - 2025-08-06
 ### Security
 - Run a user capability check before migrating WP User Avatars. Thank you Håkon Harnes at [Wordfence](https://www.wordfence.com/) for responsibly disclosing this issue. (props [@jeffpaul](https://github.com/jeffpaul), [@peterwilsoncc](https://github.com/peterwilsoncc), [@faisal-alvi](https://github.com/faisal-alvi) via [GHSA-fmhf-27jv-qf37](https://github.com/10up/simple-local-avatars/security/advisories/GHSA-fmhf-27jv-qf37))
@@ -403,6 +428,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Initial release
 
 [Unreleased]: https://github.com/10up/simple-local-avatars/compare/trunk...develop
+[2.8.6]: https://github.com/10up/simple-local-avatars/compare/2.8.5...2.8.6
 [2.8.5]: https://github.com/10up/simple-local-avatars/compare/2.8.4...2.8.5
 [2.8.4]: https://github.com/10up/simple-local-avatars/compare/2.8.3...2.8.4
 [2.8.3]: https://github.com/10up/simple-local-avatars/compare/2.8.2...2.8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Bump `playwright` from 1.48.2 to 1.56.1 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#350](https://github.com/10up/simple-local-avatars/pull/350)).
 - Bump `lodash` from 4.17.21 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#356](https://github.com/10up/simple-local-avatars/pull/356)).
 - Bump `lodash-es` from 4.17.22 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#357](https://github.com/10up/simple-local-avatars/pull/357)).
+- Bump `qs` from 6.14.1 to 6.14.2 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#361](https://github.com/10up/simple-local-avatars/pull/361)).
 
 ## [2.8.5] - 2025-08-06
 ### Security

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -4,7 +4,7 @@ The following acknowledges the Maintainers for this repository, those who have C
 
 The following individuals are responsible for curating the list of issues, responding to pull requests, and ensuring regular releases happen.
 
-[Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Faisal Alvi (@faisal-alvi)](https://github.com/faisal-alvi)
+[Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Darin Kotter (@dkotter)](https://github.com/dkotter).
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 ![Simple Local Avatars](https://github.com/10up/simple-local-avatars/blob/develop/.wordpress-org/banner-1544x500.jpg)
 
+> Adds an avatar upload field to user profiles. Generates requested sizes on demand just like Gravatar!
+
 [![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) ![Required PHP Version](https://img.shields.io/wordpress/plugin/required-php/simple-local-avatars?label=Requires%20PHP) ![Required WP Version](https://img.shields.io/wordpress/plugin/wp-version/simple-local-avatars?label=Requires%20WordPress) ![WordPress tested up to version](https://img.shields.io/wordpress/plugin/tested/simple-local-avatars?label=WordPress) [![GPLv2 License](https://img.shields.io/github/license/10up/simple-local-avatars.svg)](https://github.com/10up/simple-local-avatars/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/simple-local-avatars/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/simple-local-avatars/actions/workflows/dependency-review.yml) [![E2E Tests](https://github.com/10up/simple-local-avatars/actions/workflows/cypress.yml/badge.svg)](https://github.com/10up/simple-local-avatars/actions/workflows/cypress.yml) [![Linting](https://github.com/10up/simple-local-avatars/actions/workflows/lint.yml/badge.svg)](https://github.com/10up/simple-local-avatars/actions/workflows/lint.yml) ![PHPCompatibility](https://github.com/10up/simple-local-avatars/actions/workflows/php-compatibility.yml/badge.svg) [![PHPUnit](https://github.com/10up/simple-local-avatars/actions/workflows/test.yml/badge.svg)](https://github.com/10up/simple-local-avatars/actions/workflows/test.yml) [![CodeQL](https://github.com/10up/simple-local-avatars/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/10up/simple-local-avatars/actions/workflows/github-code-scanning/codeql) [![WordPress Playground Demo](https://img.shields.io/wordpress/plugin/v/simple-local-avatars?logo=wordpress&logoColor=FFFFFF&label=Playground%20Demo&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/simple-local-avatars/trunk/.wordpress-org/blueprints/blueprint.json)
 
-> Adds an avatar upload field to user profiles. Generates requested sizes on demand just like Gravatar!
+> [!NOTE]  
+> Simple Local Avatars' support level is marked as `stable`.  10up is not planning to develop any new features for this, but will still respond to bug reports and security concerns.  We welcome PRs, but any that include new features should be small and easy to integrate and should not include breaking changes.  We otherwise intend to keep this tested up to the most recent version of WordPress.
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-local-avatars",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-local-avatars",
-      "version": "2.8.5",
+      "version": "2.8.6",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@10up/cypress-wp-utils": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-local-avatars",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Adds an avatar upload field to user profiles. Generates requested sizes on demand just like Gravatar!",
   "license": "GPL-2.0-or-later",
   "author": "10up <opensource@10up.com> (https://10up.com)",

--- a/readme.txt
+++ b/readme.txt
@@ -60,17 +60,6 @@ Please report security bugs found in the source code of the Simple Local Avatars
 * **Changed:** Consider `wp_verify_nonce()` as auto-sanitized (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
 * **Fixed:** Ensure form data is unslashed as required (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
 * **Security:** (Hardening) Ensure user has `manage_option` cap before saving default avatar (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
-* **Developer:** Ensure our final release asset gets attached properly to the release (props [@dkotter](https://github.com/dkotter), [@jeffpaul](https://github.com/jeffpaul) via [#340](https://github.com/10up/simple-local-avatars/pull/340)).
-* **Developer:** Add Patchstack security-reporting FAQ (props [@jeffpaul](https://github.com/jeffpaul) via [#355](https://github.com/10up/simple-local-avatars/pull/355)).
-* **Developer:** Update dependencies via `npm audit fix` (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#354](https://github.com/10up/simple-local-avatars/pull/354)).
-* **Developer:** Bump `on-headers` from 1.0.2 to 1.1.0 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#341](https://github.com/10up/simple-local-avatars/pull/341)).
-* **Developer:** Bump `compression` from 1.7.5 to 1.8.1 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#341](https://github.com/10up/simple-local-avatars/pull/341)).
-* **Developer:** Bump `form-data` from 4.0.1 to 4.0.4 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#346](https://github.com/10up/simple-local-avatars/pull/346)).
-* **Developer:** Bump `tmp` from 0.2.3 to 0.2.5 (props [@dependabot](https://github.com/apps/dependabot), [@Sidsector9](hhttps://github.com/Sidsector9) via [#347](https://github.com/10up/simple-local-avatars/pull/347)).
-* **Developer:** Bump `@wordpress/env` from 10.11.0 to 10.28.0 (props [@dependabot](https://github.com/apps/dependabot), [@Sidsector9](hhttps://github.com/Sidsector9) via [#347](https://github.com/10up/simple-local-avatars/pull/347)).
-* **Developer:** Bump `playwright` from 1.48.2 to 1.56.1 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#350](https://github.com/10up/simple-local-avatars/pull/350)).
-* **Developer:** Bump `lodash` from 4.17.21 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#356](https://github.com/10up/simple-local-avatars/pull/356)).
-* **Developer:** Bump `lodash-es` from 4.17.22 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#357](https://github.com/10up/simple-local-avatars/pull/357)).
 
 = 2.8.5 - 2025-08-06 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      jakemgold, 10up, thinkoomph, jeffpaul, faisal03
 Donate link:       https://10up.com/plugins/simple-local-avatars-wordpress/
 Tags:              avatar, gravatar, user photos, users, profile
 Tested up to:      6.9
-Stable tag:        2.8.5
+Stable tag:        2.8.6
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -49,10 +49,31 @@ Please report security bugs found in the source code of the Simple Local Avatars
 
 == Changelog ==
 
+= 2.8.6 - 2026-02-17 =
+
+* **Changed:** Bump WordPress "tested up to" version 6.9 (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#352](https://github.com/10up/simple-local-avatars/pull/352)).
+* **Changed:** Consider `get_avatar()` wrapper function `get_simple_local_avatar()` escaped (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+* **Changed:** Consider `wp_verify_nonce()` as auto-sanitized (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+* **Fixed:** Ensure form data is unslashed as required (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+* **Security:** (Hardening) Ensure user has `manage_option` cap before saving default avatar (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#358](https://github.com/10up/simple-local-avatars/pull/358)).
+* **Developer:** Ensure our final release asset gets attached properly to the release (props [@dkotter](https://github.com/dkotter), [@jeffpaul](https://github.com/jeffpaul) via [#340](https://github.com/10up/simple-local-avatars/pull/340)).
+* **Developer:** Add Patchstack security-reporting FAQ (props [@jeffpaul](https://github.com/jeffpaul) via [#355](https://github.com/10up/simple-local-avatars/pull/355)).
+* **Developer:** Update dependencies via `npm audit fix` (props [@peterwilsoncc](https://github.com/peterwilsoncc), [@dkotter](https://github.com/dkotter) via [#354](https://github.com/10up/simple-local-avatars/pull/354)).
+* **Developer:** Bump `on-headers` from 1.0.2 to 1.1.0 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#341](https://github.com/10up/simple-local-avatars/pull/341)).
+* **Developer:** Bump `compression` from 1.7.5 to 1.8.1 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#341](https://github.com/10up/simple-local-avatars/pull/341)).
+* **Developer:** Bump `form-data` from 4.0.1 to 4.0.4 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#346](https://github.com/10up/simple-local-avatars/pull/346)).
+* **Developer:** Bump `tmp` from 0.2.3 to 0.2.5 (props [@dependabot](https://github.com/apps/dependabot), [@Sidsector9](hhttps://github.com/Sidsector9) via [#347](https://github.com/10up/simple-local-avatars/pull/347)).
+* **Developer:** Bump `@wordpress/env` from 10.11.0 to 10.28.0 (props [@dependabot](https://github.com/apps/dependabot), [@Sidsector9](hhttps://github.com/Sidsector9) via [#347](https://github.com/10up/simple-local-avatars/pull/347)).
+* **Developer:** Bump `playwright` from 1.48.2 to 1.56.1 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#350](https://github.com/10up/simple-local-avatars/pull/350)).
+* **Developer:** Bump `lodash` from 4.17.21 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#356](https://github.com/10up/simple-local-avatars/pull/356)).
+* **Developer:** Bump `lodash-es` from 4.17.22 to 4.17.23 (props [@dependabot](https://github.com/apps/dependabot), [@dkotter](https://github.com/dkotter) via [#357](https://github.com/10up/simple-local-avatars/pull/357)).
+
 = 2.8.5 - 2025-08-06 =
+
 * **Security:** Run a user capability check before migrating WP User Avatars. Thank you Håkon Harnes at [Wordfence](https://www.wordfence.com/) for responsibly disclosing this issue. (props [@jeffpaul](https://github.com/jeffpaul), [@peterwilsoncc](https://github.com/peterwilsoncc), [@faisal-alvi](https://github.com/faisal-alvi) via [GHSA-fmhf-27jv-qf37](https://github.com/10up/simple-local-avatars/security/advisories/GHSA-fmhf-27jv-qf37))
 
 = 2.8.4 - 2025-07-14 =
+
 * **Changed:** Don't resize image if the full version already has the expected height/width (props [@ocean90](https://github.com/ocean90), [@jeffpaul](https://github.com/jeffpaul), [@faisal-alvi](https://github.com/faisal-alvi) via [#324](https://github.com/10up/simple-local-avatars/pull/324)).
 * **Changed:** Bump WordPress "tested up to" version 6.8 (props [@qasumitbagthariya](https://github.com/qasumitbagthariya), [@dkotter](https://github.com/dkotter), [@jeffpaul](https://github.com/jeffpaul) via [#332](https://github.com/10up/simple-local-avatars/pull/332), [#334](https://github.com/10up/simple-local-avatars/pull/334)).
 * **Changed:** Bump WordPress minimum from 6.5 to 6.6 (props [@qasumitbagthariya](https://github.com/qasumitbagthariya), [@dkotter](https://github.com/dkotter), [@jeffpaul](https://github.com/jeffpaul) via [#332](https://github.com/10up/simple-local-avatars/pull/332), [#334](https://github.com/10up/simple-local-avatars/pull/334)).
@@ -60,17 +81,6 @@ Please report security bugs found in the source code of the Simple Local Avatars
 * **Security:** Bump `axios` from 1.7.7 to 1.8.4 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#330](https://github.com/10up/simple-local-avatars/pull/330)).
 * **Security:** Bump `tar-fs` from 3.0.6 to 3.0.9 (props [@dependabot](https://github.com/apps/dependabot), [@faisal-alvi](https://github.com/faisal-alvi) via [#331](https://github.com/10up/simple-local-avatars/pull/331), [#336](https://github.com/10up/simple-local-avatars/pull/336)).
 * **Security:** Bump `http-proxy-middleware` from 2.0.7 to 2.0.9 (props [@dependabot](https://github.com/apps/dependabot), [@peterwilsoncc](https://github.com/peterwilsoncc) via [#335](https://github.com/10up/simple-local-avatars/pull/335)).
-
-= 2.8.3 - 2024-11-18 =
-* **Changed:** Only allow images that were uploaded by the same user be used when setting the avatar via a REST request (props [@dkotter](https://github.com/dkotter), [@justus12337](https://github.com/justus12337), [@faisal-alvi](https://github.com/faisal-alvi) via [#317](https://github.com/10up/simple-local-avatars/pull/317)).
-* **Fixed:** Only allow image files to be set as the avatar in REST requests (props [@dkotter](https://github.com/dkotter), [@justus12337](https://github.com/justus12337), [@faisal-alvi](https://github.com/faisal-alvi) via [#317](https://github.com/10up/simple-local-avatars/pull/317)).
-* **Security:** Bump `@10up/cypress-wp-utils` from 0.2.0 to 0.4.0, `@sentry/node` from 6.19.7 to 8.38.0, `@wordpress/env` from 9.2.0 to 10.11.0, `cypress` from 13.2.0 to 13.15.2, `cypress-mochawesome-reporter` from 3.6.0 to 3.8.2, `puppeteer-core` from 23.3.0 to 23.8.0 (props [@dkotter](https://github.com/dkotter) via [#319](https://github.com/10up/simple-local-avatars/pull/319)).
-
-= 2.8.2 - 2024-11-12 =
-* **Fixed:** Ensure dependencies are (actually) included properly in the release (props [@dkotter](https://github.com/dkotter) via [#316](https://github.com/10up/simple-local-avatars/pull/316)).
-
-= 2.8.1 - 2024-11-12 =
-* **Fixed:** Ensure dependencies are included properly in the release (props [@dkotter](https://github.com/dkotter) via [#315](https://github.com/10up/simple-local-avatars/pull/315)).
 
 [View historical changelog details here](https://github.com/10up/simple-local-avatars/blob/develop/CHANGELOG.md).
 

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,10 @@ Just edit a user profile, and scroll down to the new "Avatar" field. The plug-in
 5. Lets you decide whether lower privilege users (subscribers, contributors) can upload their own avatar.
 6. Enables rating of local avatars, just like Gravatar.
 
+== Support Level ==
+
+Simple Local Avatars' support level is marked as `stable`.  10up is not planning to develop any new features for this, but will still respond to bug reports and security concerns.  We welcome PRs, but any that include new features should be small and easy to integrate and should not include breaking changes.  We otherwise intend to keep this tested up to the most recent version of WordPress.
+
 == Installation ==
 
 1. Install easily with the WordPress plugin control panel or manually download the plugin and upload the extracted folder to the `/wp-content/plugins/` directory

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Simple Local Avatars ===
-Contributors:      jakemgold, 10up, thinkoomph, jeffpaul, faisal03
+Contributors:      jakemgold, 10up, thinkoomph, jeffpaul, faisal03, dkotter
 Donate link:       https://10up.com/plugins/simple-local-avatars-wordpress/
 Tags:              avatar, gravatar, user photos, users, profile
 Tested up to:      6.9

--- a/simple-local-avatars.php
+++ b/simple-local-avatars.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Simple Local Avatars
  * Plugin URI:        https://10up.com/plugins/simple-local-avatars-wordpress/
  * Description:       Adds an avatar upload field to user profiles. Generates requested sizes on demand, just like Gravatar! Simple and lightweight.
- * Version:           2.8.5
+ * Version:           2.8.6
  * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            10up
@@ -35,7 +35,7 @@ define( 'SLA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 require_once dirname( __FILE__ ) . '/includes/class-simple-local-avatars.php';
 
 // Global constants.
-define( 'SLA_VERSION', '2.8.5' );
+define( 'SLA_VERSION', '2.8.6' );
 define( 'SLA_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 if ( ! defined( 'SLA_IS_NETWORK' ) ) {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Version bump and prep for the 2.8.6 release.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #359.

#### Copilot summary

This pull request prepares the 2.8.6 release of Simple Local Avatars, updating version numbers, documentation, and changelogs across the project. It also adds a new support level notice, updates maintainers and contributors, and summarizes all notable changes included in this release.

The most important changes are:

**Release and Version Updates**
- Bump the plugin version to `2.8.6` in `package.json`, `simple-local-avatars.php`, and `readme.txt`, and update the `SLA_VERSION` constant. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-89bcf9fbcad3990e1db27b1f25b73fc6c0fb9be173bbcb1e719e51101f5ae40bL6-R6) [[3]](diffhunk://#diff-89bcf9fbcad3990e1db27b1f25b73fc6c0fb9be173bbcb1e719e51101f5ae40bL38-R38) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L2-R6)
- Add the 2.8.6 changelog section to `CHANGELOG.md` and `readme.txt`, summarizing all changes, fixes, and dependency updates for this release. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R31) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R56-R80)
- Add the 2.8.6 comparison link to the changelog references.

**Documentation and Communication**
- Add a "Support Level" notice to both `README.md` and `readme.txt`, clarifying that the plugin is in stable maintenance mode and outlining expectations for future contributions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R10) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R25-R28)
- Update the plugin description in `README.md` for clarity and move the feature list further down.

**Credits and Contributors**
- Add Darin Kotter (`@dkotter`) as a maintainer in `CREDITS.md` and as a contributor in `readme.txt`. [[1]](diffhunk://#diff-7ddc0d1fb1cd484a1b4abfe10b5bd46a7d455c6ecf8e3228ebb4f19029bf389cL7-R7) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L2-R6)

**Changelog Maintenance**
- Remove older changelog entries from `readme.txt` to keep it concise, directing users to the full changelog in `CHANGELOG.md`.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
