### PR TITLE
fix: validate file type before previewing avatar upload

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,6 +18,7 @@ jobs:
     name: ${{ matrix.core.name }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
 ## [Unreleased] - TBD
+### Added
+- Client-side avatar file-type validation: reject non-image and unknown-type files before preview, mirror the server's accepted JPG/GIF/PNG set, and announce rejections to assistive technology via `wp.a11y.speak` (props [@thisismyurl](https://github.com/thisismyurl), [@thrijith](https://github.com/thrijith) via [#370](https://github.com/10up/simple-local-avatars/pull/370)).
 
 ## [2.8.6] - 2026-02-17
 ### Changed

--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -147,6 +147,44 @@ jQuery(document).ready(function ($) {
 	});
 
 	/**
+	 * Image MIME types the server will actually accept on upload. Mirrors the
+	 * `mimes` allow-list passed to media_handle_upload() in
+	 * Simple_Local_Avatars::edit_user_profile_update(), so the client never
+	 * previews a file the server would reject on submit.
+	 */
+	const avatar_allowed_types = ['image/jpeg', 'image/gif', 'image/png'];
+
+	/**
+	 * Show a rejection message for an invalid avatar file and announce it to
+	 * assistive technology.
+	 *
+	 * @param {string} message Human-readable reason the file was rejected.
+	 */
+	function avatar_show_error(message) {
+		let $error = $('#simple-local-avatar-error');
+		if (!$error.length) {
+			$error = $('<span/>', {
+				id: 'simple-local-avatar-error',
+				class: 'description',
+				css: { display: 'block', color: '#d63638' },
+			});
+			avatar_input.after($error);
+		}
+		$error.text(message);
+
+		if (window.wp && wp.a11y && 'function' === typeof wp.a11y.speak) {
+			wp.a11y.speak(message, 'assertive');
+		}
+	}
+
+	/**
+	 * Clear any avatar rejection message.
+	 */
+	function avatar_clear_error() {
+		$('#simple-local-avatar-error').remove();
+	}
+
+	/**
 	 * Update the Local Avatar image
 	 */
 	avatar_input.on('change', function (event) {
@@ -155,14 +193,23 @@ jQuery(document).ready(function ($) {
 		URL.revokeObjectURL(avatar_blob);
 		if (event.target.files.length > 0) {
 			const file = event.target.files[0];
-			if (file.type && 0 !== file.type.indexOf('image/')) {
+
+			// Reject anything without a MIME type (e.g. a renamed binary the
+			// browser cannot identify, where file.type is an empty string) or
+			// outside the server's accepted set. indexOf() returns -1 for an
+			// empty/unknown type, so this guard never previews an unsafe file.
+			if (-1 === avatar_allowed_types.indexOf(file.type)) {
 				avatar_input.val('');
 				avatar_preview.attr('src', current_avatar);
+				avatar_show_error(i10n_SimpleLocalAvatars.invalidFileType);
 				return;
 			}
+
+			avatar_clear_error();
 			avatar_blob = URL.createObjectURL(file);
 			avatar_preview.attr('src', avatar_blob);
 		} else {
+			avatar_clear_error();
 			avatar_preview.attr('src', current_avatar);
 		}
 	});

--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -194,10 +194,12 @@ jQuery(document).ready(function ($) {
 		if (event.target.files.length > 0) {
 			const file = event.target.files[0];
 
-			// Reject anything without a MIME type (e.g. a renamed binary the
-			// browser cannot identify, where file.type is an empty string) or
-			// outside the server's accepted set. indexOf() returns -1 for an
-			// empty/unknown type, so this guard never previews an unsafe file.
+			/*
+			 * Reject anything without a MIME type (e.g. a renamed binary the
+			 * browser cannot identify, where file.type is an empty string) or
+			 * outside the server's accepted set. indexOf() returns -1 for an
+			 * empty/unknown type, so this guard never previews an unsafe file.
+			 */
 			if (-1 === avatar_allowed_types.indexOf(file.type)) {
 				avatar_input.val('');
 				avatar_preview.attr('src', current_avatar);

--- a/assets/js/simple-local-avatars.js
+++ b/assets/js/simple-local-avatars.js
@@ -154,7 +154,13 @@ jQuery(document).ready(function ($) {
 		avatar_preview.attr('height', 'auto');
 		URL.revokeObjectURL(avatar_blob);
 		if (event.target.files.length > 0) {
-			avatar_blob = URL.createObjectURL(event.target.files[0]);
+			const file = event.target.files[0];
+			if (file.type && 0 !== file.type.indexOf('image/')) {
+				avatar_input.val('');
+				avatar_preview.attr('src', current_avatar);
+				return;
+			}
+			avatar_blob = URL.createObjectURL(file);
 			avatar_preview.attr('src', avatar_blob);
 		} else {
 			avatar_preview.attr('src', current_avatar);

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -846,7 +846,7 @@ class Simple_Local_Avatars {
 
 		$this->remove_nonce = wp_create_nonce( 'remove_simple_local_avatar_nonce' );
 
-		wp_enqueue_script( 'simple-local-avatars', plugins_url( '', dirname( __FILE__ ) ) . '/dist/simple-local-avatars.js', array( 'jquery' ), SLA_VERSION, true );
+		wp_enqueue_script( 'simple-local-avatars', plugins_url( '', dirname( __FILE__ ) ) . '/dist/simple-local-avatars.js', array( 'jquery', 'wp-a11y' ), SLA_VERSION, true );
 		wp_localize_script(
 			'simple-local-avatars',
 			'i10n_SimpleLocalAvatars',
@@ -860,6 +860,7 @@ class Simple_Local_Avatars {
 				'mediaNonce'                      => wp_create_nonce( 'assign_simple_local_avatar_nonce' ),
 				'migrateFromWpUserAvatarNonce'    => wp_create_nonce( 'migrate_from_wp_user_avatar_nonce' ),
 				'clearCacheError'                 => esc_html__( 'Something went wrong while clearing cache, please try again.', 'simple-local-avatars' ),
+				'invalidFileType'                 => esc_html__( 'Please choose a JPG, GIF, or PNG image.', 'simple-local-avatars' ),
 				'insertMediaTitle'                => esc_html__( 'Choose default avatar', 'simple-local-avatars' ),
 				'migrateFromWpUserAvatarSuccess'  => __( 'Number of avatars successfully migrated from WP User Avatar', 'simple-local-avatars' ),
 				'migrateFromWpUserAvatarFailure'  => __( 'No avatars were migrated from WP User Avatar.', 'simple-local-avatars' ),
@@ -990,7 +991,7 @@ class Simple_Local_Avatars {
 										?>
 										<p style="display: inline-block; width: 26em;">
 											<span class="description"><?php esc_html_e( 'Choose an image from your computer:', 'simple-local-avatars' ); ?></span><br />
-											<input type="file" name="simple-local-avatar" id="simple-local-avatar" class="standard-text" accept="image/*" />
+											<input type="file" name="simple-local-avatar" id="simple-local-avatar" class="standard-text" accept="image/jpeg,image/png,image/gif" />
 										</p>
 									<?php } ?>
 									<p style="width: 28em">

--- a/includes/class-simple-local-avatars.php
+++ b/includes/class-simple-local-avatars.php
@@ -990,7 +990,7 @@ class Simple_Local_Avatars {
 										?>
 										<p style="display: inline-block; width: 26em;">
 											<span class="description"><?php esc_html_e( 'Choose an image from your computer:', 'simple-local-avatars' ); ?></span><br />
-											<input type="file" name="simple-local-avatar" id="simple-local-avatar" class="standard-text" />
+											<input type="file" name="simple-local-avatar" id="simple-local-avatar" class="standard-text" accept="image/*" />
 										</p>
 									<?php } ?>
 									<p style="width: 28em">

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 wp-env run tests-wordpress chmod -c ugo+w /var/www/html
 wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
+# Subscriber (no upload_files cap) sees the plain avatar file input instead of the media library.
+wp-env run tests-cli wp user create subscriber subscriber@example.com --role=subscriber --user_pass=password || true

--- a/tests/cypress/integration/avatar-file-type.test.js
+++ b/tests/cypress/integration/avatar-file-type.test.js
@@ -1,0 +1,39 @@
+import 'cypress-file-upload';
+
+describe('Avatar upload file-type validation', () => {
+    beforeEach(() => {
+        cy.login();
+        cy.visit('/wp-admin/profile.php');
+    });
+
+    it('Rejects a non-image file and tells the user why', () => {
+        cy.get('#simple-local-avatar').attachFile({
+            fileContent: 'not really an image',
+            fileName: 'not-an-image.txt',
+            mimeType: 'text/plain',
+        });
+
+        // The selection is cleared and the rejection is surfaced.
+        cy.get('#simple-local-avatar').should('have.value', '');
+        cy.get('#simple-local-avatar-error').should('be.visible');
+    });
+
+    it('Rejects a file with no detectable MIME type', () => {
+        // A renamed binary the browser cannot identify reports an empty type.
+        cy.get('#simple-local-avatar').attachFile({
+            fileContent: 'renamed binary, no type',
+            fileName: 'mystery.bin',
+            mimeType: '',
+        });
+
+        cy.get('#simple-local-avatar').should('have.value', '');
+        cy.get('#simple-local-avatar-error').should('be.visible');
+    });
+
+    it('Accepts a valid image and shows no error', () => {
+        cy.get('#simple-local-avatar').attachFile('../../../.wordpress-org/icon-256x256.png');
+
+        cy.get('#simple-local-avatar-error').should('not.exist');
+        cy.get('#simple-local-avatar').should('not.have.value', '');
+    });
+});

--- a/tests/cypress/integration/avatar-file-type.test.js
+++ b/tests/cypress/integration/avatar-file-type.test.js
@@ -2,7 +2,9 @@ import 'cypress-file-upload';
 
 describe('Avatar upload file-type validation', () => {
     beforeEach(() => {
-        cy.login();
+        // Admins get the media-library uploader; the plain file input this suite
+        // exercises only renders for users without the upload_files capability.
+        cy.login('subscriber', 'password');
         cy.visit('/wp-admin/profile.php');
     });
 

--- a/tests/cypress/integration/avatar-file-type.test.js
+++ b/tests/cypress/integration/avatar-file-type.test.js
@@ -1,5 +1,3 @@
-import 'cypress-file-upload';
-
 describe('Avatar upload file-type validation', () => {
     beforeEach(() => {
         // Admins get the media-library uploader; the plain file input this suite
@@ -9,8 +7,8 @@ describe('Avatar upload file-type validation', () => {
     });
 
     it('Rejects a non-image file and tells the user why', () => {
-        cy.get('#simple-local-avatar').attachFile({
-            fileContent: 'not really an image',
+        cy.get('#simple-local-avatar').selectFile({
+            contents: Cypress.Buffer.from('not really an image'),
             fileName: 'not-an-image.txt',
             mimeType: 'text/plain',
         });
@@ -22,8 +20,8 @@ describe('Avatar upload file-type validation', () => {
 
     it('Rejects a file with no detectable MIME type', () => {
         // A renamed binary the browser cannot identify reports an empty type.
-        cy.get('#simple-local-avatar').attachFile({
-            fileContent: 'renamed binary, no type',
+        cy.get('#simple-local-avatar').selectFile({
+            contents: Cypress.Buffer.from('renamed binary, no type'),
             fileName: 'mystery.bin',
             mimeType: '',
         });
@@ -33,7 +31,15 @@ describe('Avatar upload file-type validation', () => {
     });
 
     it('Accepts a valid image and shows no error', () => {
-        cy.get('#simple-local-avatar').attachFile('../../../.wordpress-org/icon-256x256.png');
+        // Minimal 1x1 PNG; the guard only inspects the reported MIME type.
+        cy.get('#simple-local-avatar').selectFile({
+            contents: Cypress.Buffer.from(
+                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                'base64'
+            ),
+            fileName: 'avatar.png',
+            mimeType: 'image/png',
+        });
 
         cy.get('#simple-local-avatar-error').should('not.exist');
         cy.get('#simple-local-avatar').should('not.have.value', '');

--- a/tests/cypress/integration/check-avatar-fe.test.js
+++ b/tests/cypress/integration/check-avatar-fe.test.js
@@ -55,6 +55,7 @@ describe("Check avatar on a  post", () => {
 
     // Use the REST API to create a post so this test is not coupled to
     // block editor UI selectors, which change across WP versions.
+    cy.visit("/wp-admin/");
     cy.window()
       .its("wpApiSettings.nonce")
       .then((nonce) => {

--- a/tests/cypress/integration/check-avatar-fe.test.js
+++ b/tests/cypress/integration/check-avatar-fe.test.js
@@ -53,15 +53,23 @@ describe("Check avatar on a  post", () => {
       }
     });
 
-    cy.createPost({
-      title: "Test Simple Avatars Post",
-    }).then((post) => {
-      // Check the FE
-      cy.visit(`/?p=${post.id}`);
-      cy.get(".author-bio .avatar").should("be.visible");
-      cy.get(".author-bio .avatar")
-        .invoke("attr", "src")
-        .should("include", "icon-256x256");
-    });
+    // Use the REST API to create a post so this test is not coupled to
+    // block editor UI selectors, which change across WP versions.
+    cy.window()
+      .its("wpApiSettings.nonce")
+      .then((nonce) => {
+        cy.request({
+          method: "POST",
+          url: "/wp-json/wp/v2/posts",
+          headers: { "X-WP-Nonce": nonce },
+          body: { title: "Test Simple Avatars Post", status: "publish" },
+        }).then((response) => {
+          cy.visit(`/?p=${response.body.id}`);
+          cy.get(".author-bio .avatar").should("be.visible");
+          cy.get(".author-bio .avatar")
+            .invoke("attr", "src")
+            .should("include", "icon-256x256");
+        });
+      });
   });
 });


### PR DESCRIPTION
### Description of the Change

The local-file avatar file input accepted any file type — a user could select a PDF, video, or binary and `URL.createObjectURL()` would attempt to render it as an image preview. Two changes close this gap:

- **PHP (`class-simple-local-avatars.php`):** Add `accept="image/jpeg,image/png,image/gif"` to the `<input type="file">` so the OS file picker defaults to images and supporting browsers pre-filter the dialog.
- **JS (`assets/js/simple-local-avatars.js`):** Add a MIME-type guard in the `change` event handler that mirrors the server-side allow-list (`image/jpeg`, `image/gif`, `image/png`). If the selected file's reported `type` is absent or outside that set, the input is cleared, the existing avatar preview is restored, and a localised rejection message is inserted and announced via `wp.a11y.speak()` for screen readers. The `wp-a11y` script is added as a dependency so `wp.a11y` is always available.
- **Tests (`tests/cypress/integration/avatar-file-type.test.js`):** Three Cypress tests cover the rejection, empty-type, and valid-image paths. They run as a subscriber because admins see the media-library uploader rather than the plain file input this feature guards.

Closes #233

### How to test the Change

1. Log in as a user without the `upload_files` capability (e.g. the subscriber created by `tests/bin/initialize.sh`).
2. Go to **Users → Profile**.
3. Under the local avatar field, attempt to select a non-image file (e.g. `.pdf`, `.txt`, `.exe`).
4. Confirm the input is cleared, the existing avatar preview is unchanged, and an error message appears below the field.
5. Confirm selecting a valid JPEG, PNG, or GIF image clears the error and updates the preview.
6. Confirm the error message is announced by a screen reader (if available).
7. Confirm the admin/media-library upload path is unaffected.

### Changelog Entry

- Add `accept` attribute to avatar file input to filter the OS file picker to images
- Add client-side MIME-type guard that rejects non-image files before preview and surfaces an accessible error message

### Credits

Props @thisismyurl