### PR TITLE
WP Compatibility Check Against WP Core 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      jakemgold, 10up, thinkoomph, jeffpaul, faisal03, dkotter
 Donate link:       https://10up.com/plugins/simple-local-avatars-wordpress/
 Tags:              avatar, gravatar, user photos, users, profile
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        2.8.6
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change
Tested compatibility against WP Core 7.1 RC1. The plugin functions as expected with the 7.1 RC1

Closes #373 

### How to test the Change

1. Update WP Core version to 7.1 RC1 using any methods described [here](https://wordpress.org/news/2026/08/wordpress-7-1-release-candidate-1/)
2. Navigate to any screens and there should be no warnings and/or errors.
3. The plugin functionality works as expected

### Changelog Entry
> Developer - Bumped up Tested up to from 7.0 to 7.1

### Credits
Props @zamanq 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
